### PR TITLE
remove the Recovery limits

### DIFF
--- a/pkg/rabbitmqamqp/amqp_connection_recovery.go
+++ b/pkg/rabbitmqamqp/amqp_connection_recovery.go
@@ -22,6 +22,12 @@ type RecoveryConfiguration struct {
 	BackOffReconnectInterval time.Duration
 
 	/*
+		Jitter used to add randomness to the reconnection interval.
+		Default is 500 milliseconds.
+	*/
+	Jitter time.Duration
+
+	/*
 		MaxReconnectAttempts The maximum number of reconnection attempts.
 		Default is 5.
 		The minimum value is 1.
@@ -34,6 +40,7 @@ func (c *RecoveryConfiguration) Clone() *RecoveryConfiguration {
 		ActiveRecovery:           c.ActiveRecovery,
 		BackOffReconnectInterval: c.BackOffReconnectInterval,
 		MaxReconnectAttempts:     c.MaxReconnectAttempts,
+		Jitter:                   c.Jitter,
 	}
 
 	return cloned
@@ -45,6 +52,7 @@ func NewRecoveryConfiguration() *RecoveryConfiguration {
 		ActiveRecovery:           true,
 		BackOffReconnectInterval: 5 * time.Second,
 		MaxReconnectAttempts:     5,
+		Jitter:                   500 * time.Millisecond,
 	}
 }
 

--- a/pkg/rabbitmqamqp/amqp_connection_recovery_test.go
+++ b/pkg/rabbitmqamqp/amqp_connection_recovery_test.go
@@ -29,8 +29,9 @@ var _ = Describe("Recovery connection test", func() {
 			// reduced the reconnect interval to speed up the test
 			RecoveryConfiguration: &RecoveryConfiguration{
 				ActiveRecovery:           true,
-				BackOffReconnectInterval: 2 * time.Second,
+				BackOffReconnectInterval: 1 * time.Second,
 				MaxReconnectAttempts:     5,
+				Jitter:                   200 * time.Millisecond,
 			},
 			Id: "reconnect producers and consumers",
 		})
@@ -178,18 +179,6 @@ var _ = Describe("Recovery connection test", func() {
 	It("validate the Recovery connection parameters", func() {
 
 		_, err := Dial(context.Background(), "amqp://", &AmqpConnOptions{
-			SASLType: amqp.SASLTypeAnonymous(),
-			// reduced the reconnect interval to speed up the test
-			RecoveryConfiguration: &RecoveryConfiguration{
-				ActiveRecovery:           true,
-				BackOffReconnectInterval: 500 * time.Millisecond,
-				MaxReconnectAttempts:     5,
-			},
-		})
-		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(ContainSubstring("BackOffReconnectInterval should be greater than"))
-
-		_, err = Dial(context.Background(), "amqp://", &AmqpConnOptions{
 			SASLType: amqp.SASLTypeAnonymous(),
 			RecoveryConfiguration: &RecoveryConfiguration{
 				ActiveRecovery:       true,


### PR DESCRIPTION
Remove the backoff limits.
Closes: https://github.com/rabbitmq/rabbitmq-amqp-go-client/issues/41

@OneSeven can you please try?

```golang
RecoveryConfiguration: &RecoveryConfiguration{
				ActiveRecovery:           true,
				BackOffReconnectInterval: 0,
				MaxReconnectAttempts:     500,
				Jitter:                   0,
			},
```

