### PR TITLE
Fixed declaring exchange not setting arguments

### DIFF
--- a/pkg/rabbitmqamqp/amqp_exchange.go
+++ b/pkg/rabbitmqamqp/amqp_exchange.go
@@ -61,6 +61,10 @@ func (e *AmqpExchange) AutoDelete(isAutoDelete bool) {
 	e.isAutoDelete = isAutoDelete
 }
 
+func (e *AmqpExchange) Arguments(arguments map[string]any) {
+	e.arguments = arguments
+}
+
 func (e *AmqpExchange) IsAutoDelete() bool {
 	return e.isAutoDelete
 }

--- a/pkg/rabbitmqamqp/amqp_management.go
+++ b/pkg/rabbitmqamqp/amqp_management.go
@@ -200,6 +200,7 @@ func (a *AmqpManagement) DeclareExchange(ctx context.Context, exchangeSpecificat
 	exchange := newAmqpExchange(a, exchangeSpecification.name())
 	exchange.AutoDelete(exchangeSpecification.isAutoDelete())
 	exchange.ExchangeType(exchangeSpecification.exchangeType())
+	exchange.Arguments(exchangeSpecification.arguments())
 	return exchange.Declare(ctx)
 }
 


### PR DESCRIPTION
Hi, 
This PR fixes a bug where exchange arguments weren’t applied during declaration. Now, AmqpExchange.Arguments() ensures they’re passed as expected.