### PR TITLE
Add settings to the stream queues

### DIFF
--- a/pkg/rabbitmqamqp/entities.go
+++ b/pkg/rabbitmqamqp/entities.go
@@ -407,6 +407,7 @@ type StreamQueueSpecification struct {
 	InitialClusterSize int
 	MaxAge             time.Duration
 	SegmentSize        int64
+	FilterSizeBytes    int64
 	Arguments          map[string]any
 }
 
@@ -446,6 +447,10 @@ func (s *StreamQueueSpecification) buildArguments() map[string]any {
 
 	if s.SegmentSize != 0 {
 		result["x-stream-max-segment-size-bytes"] = s.SegmentSize
+	}
+
+	if s.FilterSizeBytes != 0 {
+		result["x-stream-filter-size-bytes"] = s.FilterSizeBytes
 	}
 
 	result["x-queue-type"] = string(s.queueType())

--- a/pkg/rabbitmqamqp/entities_test.go
+++ b/pkg/rabbitmqamqp/entities_test.go
@@ -64,6 +64,21 @@ var _ = Describe("Entities", func() {
 			Expect(args["x-stream-max-segment-size-bytes"]).To(Equal(int64(100_000_000)))
 		})
 
+		It("should set x-stream-filter-size-bytes when FilterSizeBytes is set", func() {
+			spec := &StreamQueueSpecification{
+				Name:            "my-stream",
+				FilterSizeBytes: 16,
+			}
+			args := spec.buildArguments()
+			Expect(args["x-stream-filter-size-bytes"]).To(Equal(int64(16)))
+		})
+
+		It("should not set x-stream-filter-size-bytes when FilterSizeBytes is zero", func() {
+			spec := &StreamQueueSpecification{Name: "my-stream"}
+			args := spec.buildArguments()
+			Expect(args).ToNot(HaveKey("x-stream-filter-size-bytes"))
+		})
+
 		It("should always set x-queue-type to stream", func() {
 			spec := &StreamQueueSpecification{Name: "my-stream"}
 			args := spec.buildArguments()


### PR DESCRIPTION
Adds additional configuration knobs for RabbitMQ stream queues by extending `StreamQueueSpecification` and introducing a duration-to-`x-max-age` formatter, with accompanying unit tests.

**Changes:**
- Extend `StreamQueueSpecification` to support `x-stream-filter-size-bytes`, `x-max-age` and `x-stream-max-segment-size-bytes`.
- Add `durationToMaxAge(time.Duration)` helper to format RabbitMQ `x-max-age` values.
- Add Ginkgo/Gomega tests for the new arguments and duration conversion.

Closes https://github.com/rabbitmq/rabbitmq-amqp-go-client/issues/64