### PR TITLE
Add release.yml for changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - skip-changelog
+  categories:
+    - title: 🚨 Breaking Changes
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: ✨ Enhancements
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - Semver-Patch
+        - bug
+        - bug-fix
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🔄 Dependency Updates
+      labels:
+        - dependencies
+    - title: 🔧 Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION

Adds a GitHub Releases auto-generated release notes configuration to standardize changelog categorization based on PR labels.

**Changes:**
- Introduce `.github/release.yml` to configure changelog exclusions and category grouping for GitHub-generated release notes.
- Define label-based categories for breaking changes, enhancements, bug fixes, documentation, dependency updates, and a catch-all.
