### PR TITLE
Add PublishAsync to Publisher for non-blocking message publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ format:
 vet:
 	go vet ./pkg/rabbitmqamqp
 	go vet ./docs/examples/...
+	go vet ./docs/perf_test/...
+
 
 STATICCHECK ?= $(GOBIN)/staticcheck
 STATICCHECK_VERSION ?= latest
@@ -21,6 +23,7 @@ $(STATICCHECK):
 check: $(STATICCHECK)
 	$(STATICCHECK) ./pkg/rabbitmqamqp
 	$(STATICCHECK) ./docs/examples/...
+	$(STATICCHECK) ./docs/perf_test/...
 
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ This library is meant to be used with RabbitMQ `4.x`.
 - Getting started Video tutorial: </br>
 [![Getting Started](https://img.youtube.com/vi/iR1JUFh3udI/0.jpg)](https://youtu.be/iR1JUFh3udI)
 
+## Performance test
 
+You can find a performance test in `docs/perf_test/`. 
+This client supports two ways to publish messages:
+- With the `Publish` method, which is a simple way to publish messages.
+- With the `PublishAsync` method, which allows you to publish messages asynchronously 
+  and get a confirmation when the message is published. This is useful for high throughput scenarios.
+  `PublishAsync` can be tuned with the `PublisherOptions` to achieve better performance.
+  Note: With a large MaxInFlight the library can use memory since it tracks all the messages in flight.
 
 ## Documentation
 

--- a/docs/examples/publish_async/main.go
+++ b/docs/examples/publish_async/main.go
@@ -1,0 +1,169 @@
+// RabbitMQ AMQP 1.0 Go Client: https://github.com/rabbitmq/rabbitmq-amqp-go-client
+// RabbitMQ AMQP 1.0 documentation: https://www.rabbitmq.com/docs/amqp
+// The example demonstrates how to use PublishAsync to send messages without blocking
+// the caller while waiting for broker confirmation.
+//
+// Key concepts shown:
+//   - PublishAsync fires the send immediately and delivers the outcome via a callback.
+//   - MaxInFlight limits how many confirmation goroutines can run concurrently,
+//     providing back-pressure: PublishAsync blocks the caller when the limit is reached.
+//   - PublishTimeout controls how long each confirmation goroutine waits for the broker
+//     before the callback receives a timeout error.
+//   - A sync.WaitGroup is used to wait for all callbacks before shutting down.
+//
+// example path: https://github.com/rabbitmq/rabbitmq-amqp-go-client/tree/main/docs/examples/publish_async/main.go
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
+)
+
+func main() {
+	const (
+		queueName      = "publish-async-go-queue"
+		totalMessages  = 2_000_000
+		maxInFlight    = 100
+		publishTimeout = 10 * time.Second
+	)
+
+	rmq.Info("PublishAsync example starting")
+
+	// Counters updated from the callback goroutines.
+	var accepted, released, rejected, failed atomic.Int32
+
+	// Track how long the whole publish loop takes.
+	startTime := time.Now()
+
+	// stateChanged receives connection lifecycle events.
+	stateChanged := make(chan *rmq.StateChanged, 1)
+	go func(ch chan *rmq.StateChanged) {
+		for sc := range ch {
+			rmq.Info("[connection] status changed", "from", sc.From, "to", sc.To)
+		}
+	}(stateChanged)
+
+	env := rmq.NewEnvironment("amqp://guest:guest@localhost:5672/", nil)
+	amqpConnection, err := env.NewConnection(context.Background())
+	if err != nil {
+		rmq.Error("Error opening connection", "error", err)
+		return
+	}
+	amqpConnection.NotifyStatusChange(stateChanged)
+	rmq.Info("AMQP connection opened")
+
+	management := amqpConnection.Management()
+	queueInfo, err := management.DeclareQueue(context.Background(), &rmq.QuorumQueueSpecification{
+		Name: queueName,
+	})
+	if err != nil {
+		rmq.Error("Error declaring queue", "error", err)
+		return
+	}
+
+	// Create the publisher with async-specific options:
+	//   MaxInFlight  – at most 100 confirmation goroutines run concurrently.
+	//                  When the limit is reached, PublishAsync blocks the caller
+	//                  until a slot becomes free.
+	//   PublishTimeout – each confirmation goroutine waits at most 30 s for a
+	//                    broker acknowledgement before the callback receives an error.
+	publisher, err := amqpConnection.NewPublisher(context.Background(),
+		&rmq.QueueAddress{Queue: queueName},
+		&rmq.PublisherOptions{
+			MaxInFlight:    maxInFlight,
+			PublishTimeout: publishTimeout,
+		})
+	if err != nil {
+		rmq.Error("Error creating publisher", "error", err)
+		return
+	}
+
+	// wg is decremented once per callback invocation.
+	var wg sync.WaitGroup
+	wg.Add(totalMessages)
+
+	for i := 0; i < totalMessages; i++ {
+		msgBody := fmt.Sprintf("hello async %d", i)
+		msg := rmq.NewMessage([]byte(msgBody))
+
+		err = publisher.PublishAsync(context.Background(), msg,
+			func(result *rmq.PublishResult, cbErr error) {
+				defer wg.Done()
+
+				if cbErr != nil {
+					// Timeout or send-level error.
+					rmq.Error("[Publisher] async callback error", "error", cbErr)
+					failed.Add(1)
+					return
+				}
+
+				switch result.Outcome.(type) {
+				case *rmq.StateAccepted:
+					accepted.Add(1)
+				case *rmq.StateReleased:
+					rmq.Warn("[Publisher] message not routed", "body", result.Message.Data[0])
+					released.Add(1)
+				case *rmq.StateRejected:
+					s := result.Outcome.(*rmq.StateRejected)
+					rmq.Warn("[Publisher] message rejected", "error", s.Error)
+					rejected.Add(1)
+				}
+			})
+
+		if err != nil {
+			// PublishAsync only returns an error for validation failures or when the
+			// caller's context is cancelled while waiting for a free in-flight slot.
+			rmq.Error("[Publisher] PublishAsync error", "error", err)
+			wg.Done()
+		}
+	}
+
+	// Block until every callback has been invoked.
+	rmq.Info("Waiting for all confirmations…")
+	wg.Wait()
+
+	elapsed := time.Since(startTime)
+	rmq.Info("All messages confirmed",
+		"accepted", accepted.Load(),
+		"released", released.Load(),
+		"rejected", rejected.Load(),
+		"failed", failed.Load(),
+		"elapsed", elapsed.Round(time.Millisecond),
+		"msg/s", fmt.Sprintf("%.0f", float64(totalMessages)/elapsed.Seconds()),
+	)
+
+	if err = publisher.Close(context.Background()); err != nil {
+		rmq.Error("Error closing publisher", "error", err)
+	}
+
+	// press any key to close
+	println("press any key to close and clean up")
+
+	var input string
+	_, _ = fmt.Scanln(&input)
+
+	purged, err := management.PurgeQueue(context.Background(), queueInfo.Name())
+	if err != nil {
+		rmq.Error("Error purging queue", "error", err)
+	} else {
+		rmq.Info("Queue purged", "messages", purged)
+	}
+
+	if err = management.DeleteQueue(context.Background(), queueInfo.Name()); err != nil {
+		rmq.Error("Error deleting queue", "error", err)
+	}
+
+	if err = env.CloseConnections(context.Background()); err != nil {
+		rmq.Error("Error closing connection", "error", err)
+	}
+
+	rmq.Info("AMQP connection closed")
+	time.Sleep(100 * time.Millisecond)
+	close(stateChanged)
+}

--- a/docs/examples/publish_async/main.go
+++ b/docs/examples/publish_async/main.go
@@ -28,7 +28,7 @@ import (
 func main() {
 	const (
 		queueName      = "publish-async-go-queue"
-		totalMessages  = 2_000_000
+		totalMessages  = 10_000_000
 		maxInFlight    = 100
 		publishTimeout = 10 * time.Second
 	)

--- a/docs/perf_test/main.go
+++ b/docs/perf_test/main.go
@@ -1,0 +1,312 @@
+// RabbitMQ AMQP 1.0 Go Client: https://github.com/rabbitmq/rabbitmq-amqp-go-client
+// Performance harness: publishes and consumes on a quorum queue while printing
+// per-second publish and consume rates (with colored console output).
+//
+// Run from the repository root:
+//
+//	go run ./docs/perf_test -mode publish
+//	go run ./docs/perf_test -mode publishAsync -address amqp://guest:guest@localhost:5672/ -queue my-queue
+//
+// example path: https://github.com/rabbitmq/rabbitmq-amqp-go-client/tree/main/docs/perf_test/main.go
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
+)
+
+// ANSI colors (works in most modern terminals).
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorBlue   = "\033[34m"
+	colorCyan   = "\033[36m"
+	colorBold   = "\033[1m"
+)
+
+// formatInt renders n with thousands separators (e.g. 1_234_567 in locale style: 1,234,567).
+func formatInt(n uint64) string {
+	s := strconv.FormatUint(n, 10)
+	if len(s) <= 3 {
+		return s
+	}
+	nDigits := len(s)
+	first := nDigits % 3
+	if first == 0 {
+		first = 3
+	}
+	var b strings.Builder
+	b.Grow(nDigits + (nDigits-1)/3)
+	b.WriteString(s[:first])
+	for i := first; i < nDigits; i += 3 {
+		b.WriteByte(',')
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
+}
+
+func main() {
+	var (
+		address      = flag.String("address", "amqp://guest:guest@localhost:5672/", "AMQP 1.0 broker URI")
+		mode         = flag.String("mode", "publish", "Publishing API: publish (sync) or publishAsync")
+		queueName    = flag.String("queue", "perf-amqp10-go-queue", "Queue name to declare and use")
+		maxInFlight  = flag.Int("maxInFlight", 256, "MaxInFlight for publishAsync (back-pressure limit)")
+		pubTimeout   = flag.Duration("publishTimeout", 0, "Broker confirmation timeout for publishAsync (0 = library default)")
+		printSummary = flag.Bool("summary", true, "Print a final summary line after shutdown")
+	)
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintln(os.Stderr, "\nModes:")
+		fmt.Fprintln(os.Stderr, "  publish       synchronous Publish() — one in-flight confirmation at a time")
+		fmt.Fprintln(os.Stderr, "  publishAsync  asynchronous PublishAsync() — up to -maxInFlight confirmations in parallel")
+	}
+	flag.Parse()
+
+	m := strings.ToLower(strings.TrimSpace(*mode))
+	if m != "publish" && m != "publishasync" {
+		fmt.Fprintf(os.Stderr, "%serror:%s unknown -mode %q (use publish or publishAsync)\n", colorRed, colorReset, *mode)
+		os.Exit(2)
+	}
+
+	var publishTotal, consumeTotal, publishErrors atomic.Uint64
+	var running atomic.Bool
+	running.Store(true)
+
+	statsStop := make(chan struct{})
+	go traceRates(statsStop, &publishTotal, &consumeTotal, &publishErrors, *queueName, m)
+
+	stateChanged := make(chan *rmq.StateChanged, 8)
+	go func() {
+		for sc := range stateChanged {
+			fmt.Printf("%s[connection]%s %v -> %v\n", colorBlue, colorReset, sc.From, sc.To)
+		}
+	}()
+
+	env := rmq.NewEnvironment(*address, nil)
+	amqpConnection, err := env.NewConnection(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%sconnection error:%s %v\n", colorRed, colorReset, err)
+		os.Exit(1)
+	}
+	amqpConnection.NotifyStatusChange(stateChanged)
+
+	management := amqpConnection.Management()
+	queueInfo, err := management.DeclareQueue(context.Background(), &rmq.QuorumQueueSpecification{
+		Name: *queueName,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%sdeclare queue:%s %v\n", colorRed, colorReset, err)
+		os.Exit(1)
+	}
+
+	consumer, err := amqpConnection.NewConsumer(context.Background(), *queueName, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%sconsumer:%s %v\n", colorRed, colorReset, err)
+		os.Exit(1)
+	}
+
+	consumeCtx, cancelConsume := context.WithCancel(context.Background())
+	go runConsumer(consumeCtx, consumer, &consumeTotal, &running)
+
+	pubOpts := &rmq.PublisherOptions{}
+	if m == "publishasync" {
+		pubOpts = &rmq.PublisherOptions{
+			MaxInFlight: *maxInFlight,
+		}
+		if *pubTimeout > 0 {
+			pubOpts.PublishTimeout = *pubTimeout
+		}
+	}
+
+	publisher, err := amqpConnection.NewPublisher(context.Background(),
+		&rmq.QueueAddress{Queue: *queueName},
+		pubOpts,
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%spublisher:%s %v\n", colorRed, colorReset, err)
+		cancelConsume()
+		os.Exit(1)
+	}
+
+	var asyncWG sync.WaitGroup
+	startRun := time.Now()
+	if m == "publishasync" {
+		go runPublisherAsync(context.Background(), publisher, &running, &asyncWG, &publishTotal, &publishErrors)
+	} else {
+		go runPublisherSync(context.Background(), publisher, &running, &publishTotal, &publishErrors)
+	}
+
+	fmt.Printf("%s%sperf_test%s queue=%s mode=%s — press Enter to stop…%s\n",
+		colorBold, colorYellow, colorReset, *queueName, m, colorReset)
+	_, _ = fmt.Scanln()
+
+	running.Store(false)
+	close(statsStop)
+	cancelConsume()
+
+	if m == "publishasync" {
+		asyncWG.Wait()
+	}
+
+	_ = consumer.Close(context.Background())
+	_ = publisher.Close(context.Background())
+
+	if *printSummary {
+		elapsed := time.Since(startRun)
+		fmt.Printf("%s[summary]%s published(accepted)=%s consumed=%s publish_errors=%s elapsed=%s\n",
+			colorBold+colorCyan, colorReset,
+			formatInt(publishTotal.Load()), formatInt(consumeTotal.Load()), formatInt(publishErrors.Load()),
+			elapsed.Round(time.Millisecond))
+	}
+
+	purged, err := management.PurgeQueue(context.Background(), queueInfo.Name())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%spurge:%s %v\n", colorRed, colorReset, err)
+	} else {
+		fmt.Printf("%s[purge]%s removed %s messages\n", colorGreen, colorReset, formatInt(uint64(purged)))
+	}
+	if err = management.DeleteQueue(context.Background(), queueInfo.Name()); err != nil {
+		fmt.Fprintf(os.Stderr, "%sdelete queue:%s %v\n", colorRed, colorReset, err)
+	}
+	if err = env.CloseConnections(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "%sclose:%s %v\n", colorRed, colorReset, err)
+	}
+	close(stateChanged)
+}
+
+func traceRates(
+	done <-chan struct{},
+	publishTotal, consumeTotal, publishErrors *atomic.Uint64,
+	queueName, mode string,
+) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var lastPub, lastCons, lastErr uint64
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			pt := publishTotal.Load()
+			ct := consumeTotal.Load()
+			pe := publishErrors.Load()
+
+			pubPerSec := pt - lastPub
+			consPerSec := ct - lastCons
+			errPerSec := pe - lastErr
+			lastPub, lastCons, lastErr = pt, ct, pe
+
+			// Publish line: cyan; consume: green; errors: red fragment.
+			fmt.Printf("%s[PUBLISH]%s %s msg/s  total %s  %s[CONSUME]%s %s msg/s  total %s",
+				colorCyan+colorBold, colorReset, formatInt(pubPerSec), formatInt(pt),
+				colorGreen+colorBold, colorReset, formatInt(consPerSec), formatInt(ct))
+			if errPerSec > 0 || pe > 0 {
+				fmt.Printf("  %s(pub err/s %s, total err %s)%s", colorRed, formatInt(errPerSec), formatInt(pe), colorReset)
+			}
+			fmt.Printf("  %s(%s %s)%s\n", colorYellow, queueName, mode, colorReset)
+		}
+	}
+}
+
+func runConsumer(
+	ctx context.Context,
+	consumer *rmq.Consumer,
+	consumeTotal *atomic.Uint64,
+	running *atomic.Bool,
+) {
+	for {
+		if !running.Load() {
+			return
+		}
+		deliveryCtx, err := consumer.Receive(ctx)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		if err != nil {
+			if running.Load() {
+				fmt.Printf("%s[consumer]%s receive error: %v\n", colorRed, colorReset, err)
+				time.Sleep(200 * time.Millisecond)
+			}
+			continue
+		}
+		consumeTotal.Add(1)
+		if err = deliveryCtx.Accept(context.Background()); err != nil && running.Load() {
+			fmt.Printf("%s[consumer]%s accept error: %v\n", colorRed, colorReset, err)
+		}
+	}
+}
+
+func runPublisherSync(
+	ctx context.Context,
+	publisher *rmq.Publisher,
+	running *atomic.Bool,
+	publishTotal, publishErrors *atomic.Uint64,
+) {
+	body := []byte("x")
+	for running.Load() {
+		res, err := publisher.Publish(ctx, rmq.NewMessage(body))
+		if err != nil {
+			publishErrors.Add(1)
+			// in case of network error, just wait a bit before trying to publish the next message
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		switch res.Outcome.(type) {
+		case *rmq.StateAccepted:
+			publishTotal.Add(1)
+		default:
+			publishErrors.Add(1)
+		}
+	}
+}
+
+func runPublisherAsync(
+	ctx context.Context,
+	publisher *rmq.Publisher,
+	running *atomic.Bool,
+	asyncWG *sync.WaitGroup,
+	publishTotal, publishErrors *atomic.Uint64,
+) {
+	body := []byte("x")
+	for running.Load() {
+		asyncWG.Add(1)
+		msg := rmq.NewMessage(body)
+		err := publisher.PublishAsync(ctx, msg, func(result *rmq.PublishResult, cbErr error) {
+			defer asyncWG.Done()
+			if cbErr != nil {
+				publishErrors.Add(1)
+				return
+			}
+			switch result.Outcome.(type) {
+			case *rmq.StateAccepted:
+				publishTotal.Add(1)
+			default:
+				publishErrors.Add(1)
+			}
+		})
+		if err != nil {
+			asyncWG.Done()
+			publishErrors.Add(1)
+			// in case of network error, just wait a bit before trying to publish the next message
+			time.Sleep(500 * time.Millisecond)
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/rabbitmqamqp/amqp_publisher.go
+++ b/pkg/rabbitmqamqp/amqp_publisher.go
@@ -177,7 +177,7 @@ The timeout for each confirmation wait is controlled by PublisherOptions.Publish
 (default 10s).
 
 PublishAsync can increase the throughput but can increase the memory usage.
-Every publish runs a go-routine that waits for the broker confirmation, so a large number of in-flight messages
+Every publish runs a goroutine that waits for the broker confirmation, so a large number of in-flight messages
 can lead to a large number of goroutines and increased memory usage.
 Use the MaxInFlight option to set an upper bound on the number of concurrent confirmations and control the memory usage.
 

--- a/pkg/rabbitmqamqp/amqp_publisher.go
+++ b/pkg/rabbitmqamqp/amqp_publisher.go
@@ -223,7 +223,9 @@ func (m *Publisher) PublishAsync(ctx context.Context, message *amqp.Message, cal
 
 		state, waitErr := receipt.Wait(waitCtx)
 		if waitErr != nil {
-			callback(nil, fmt.Errorf("publish confirmation failed: %w", waitErr))
+			if callback != nil {
+				callback(nil, fmt.Errorf("publish confirmation failed: %w", waitErr))
+			}
 			return
 		}
 

--- a/pkg/rabbitmqamqp/amqp_publisher.go
+++ b/pkg/rabbitmqamqp/amqp_publisher.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/Azure/go-amqp"
 	"github.com/google/uuid"
@@ -23,6 +24,8 @@ type Publisher struct {
 	linkName       string
 	destinationAdd string
 	id             string
+	inFlight       chan struct{}
+	publishTimeout time.Duration
 }
 
 func (m *Publisher) Id() string {
@@ -35,14 +38,27 @@ func newPublisher(ctx context.Context, connection *AmqpConnection, destinationAd
 		id = options.id()
 	}
 
-	r := &Publisher{connection: connection, linkName: getLinkName(options), destinationAdd: destinationAdd, id: id}
+	maxInFlight := DefaultMaxInFlight
+	publishTimeout := DefaultPublishTimeout
+	if options != nil {
+		maxInFlight = options.maxInFlight()
+		publishTimeout = options.publishTimeout()
+	}
+
+	r := &Publisher{
+		connection:     connection,
+		linkName:       getLinkName(options),
+		destinationAdd: destinationAdd,
+		id:             id,
+		inFlight:       make(chan struct{}, maxInFlight),
+		publishTimeout: publishTimeout,
+	}
 	connection.entitiesTracker.storeOrReplaceProducer(r)
 	err := r.createSender(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Record the publisher opening metric
 	connection.metricsCollector.OpenPublisher()
 
 	return r, nil
@@ -145,6 +161,76 @@ func (m *Publisher) Publish(ctx context.Context, message *amqp.Message) (*Publis
 		Message: message,
 		Outcome: state,
 	}, err
+}
+
+/*
+PublishAsync sends a message asynchronously and delivers the result via a callback.
+
+The message is sent to the broker immediately (same as Publish), but the confirmation
+wait (SendReceipt.Wait) happens in a background goroutine. When the broker confirms
+the message or the timeout expires, the callback is invoked with the result or an error.
+
+Back-pressure: the number of concurrent in-flight confirmations is bounded by
+MaxInFlight (configurable via PublisherOptions, default 256). When the limit is
+reached, PublishAsync blocks on the caller's goroutine until a slot becomes
+available or the context is cancelled.
+
+The timeout for each confirmation wait is controlled by PublisherOptions.PublishTimeout
+(default 10s).
+*/
+func (m *Publisher) PublishAsync(ctx context.Context, message *amqp.Message, callback PublishAsyncCallback) error {
+	if m.destinationAdd == "" {
+		if message.Properties == nil || message.Properties.To == nil {
+			return fmt.Errorf("message properties TO is required to send a message to a dynamic target address")
+		}
+		if err := validateAddress(*message.Properties.To); err != nil {
+			return err
+		}
+	}
+
+	if message.Header == nil {
+		message.Header = &amqp.MessageHeader{
+			Durable: true,
+		}
+	}
+
+	// Acquire an in-flight slot; blocks if MaxInFlight goroutines are already waiting.
+	select {
+	case m.inFlight <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	receipt, err := m.sender.Load().SendWithReceipt(ctx, message, nil)
+	if err != nil {
+		<-m.inFlight
+		return err
+	}
+
+	publishCtx := m.buildPublishContext(message)
+	m.connection.metricsCollector.Publish(publishCtx)
+
+	go func() {
+		defer func() { <-m.inFlight }()
+
+		waitCtx, cancel := context.WithTimeout(context.Background(), m.publishTimeout)
+		defer cancel()
+
+		state, waitErr := receipt.Wait(waitCtx)
+		if waitErr != nil {
+			callback(nil, fmt.Errorf("publish confirmation failed: %w", waitErr))
+			return
+		}
+
+		m.recordPublishDisposition(state, publishCtx)
+
+		callback(&PublishResult{
+			Message: message,
+			Outcome: state,
+		}, nil)
+	}()
+
+	return nil
 }
 
 // recordPublishDisposition records the publish disposition metric based on the delivery state.

--- a/pkg/rabbitmqamqp/amqp_publisher.go
+++ b/pkg/rabbitmqamqp/amqp_publisher.go
@@ -218,7 +218,7 @@ func (m *Publisher) PublishAsync(ctx context.Context, message *amqp.Message, cal
 	go func() {
 		defer func() { <-m.inFlight }()
 
-		waitCtx, cancel := context.WithTimeout(context.Background(), m.publishTimeout)
+		waitCtx, cancel := context.WithTimeout(ctx, m.publishTimeout)
 		defer cancel()
 
 		state, waitErr := receipt.Wait(waitCtx)

--- a/pkg/rabbitmqamqp/amqp_publisher.go
+++ b/pkg/rabbitmqamqp/amqp_publisher.go
@@ -114,10 +114,6 @@ You can set the message to be non-persistent by setting the Header.Durable to fa
 Note:
 When you use the `Header` is up to you to set the message properties,
 You need set the `Header.Durable` to true or false.
-
-<code>
-
-</code>
 */
 func (m *Publisher) Publish(ctx context.Context, message *amqp.Message) (*PublishResult, error) {
 	if m.destinationAdd == "" {
@@ -175,8 +171,17 @@ MaxInFlight (configurable via PublisherOptions, default 256). When the limit is
 reached, PublishAsync blocks on the caller's goroutine until a slot becomes
 available or the context is cancelled.
 
+MaxInFlight could be potentially the unacked messages in the FIFO queues.
+
 The timeout for each confirmation wait is controlled by PublisherOptions.PublishTimeout
 (default 10s).
+
+PublishAsync can increase the throughput but can increase the memory usage.
+Every publish runs a go-routine that waits for the broker confirmation, so a large number of in-flight messages
+can lead to a large number of goroutines and increased memory usage.
+Use the MaxInFlight option to set an upper bound on the number of concurrent confirmations and control the memory usage.
+
+callback is optional, you can set it to nil if you don't want to receive the Publish result.
 */
 func (m *Publisher) PublishAsync(ctx context.Context, message *amqp.Message, callback PublishAsyncCallback) error {
 	if m.destinationAdd == "" {
@@ -223,11 +228,12 @@ func (m *Publisher) PublishAsync(ctx context.Context, message *amqp.Message, cal
 		}
 
 		m.recordPublishDisposition(state, publishCtx)
-
-		callback(&PublishResult{
-			Message: message,
-			Outcome: state,
-		}, nil)
+		if callback != nil {
+			callback(&PublishResult{
+				Message: message,
+				Outcome: state,
+			}, nil)
+		}
 	}()
 
 	return nil

--- a/pkg/rabbitmqamqp/amqp_publisher_test.go
+++ b/pkg/rabbitmqamqp/amqp_publisher_test.go
@@ -2,6 +2,9 @@ package rabbitmqamqp
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/Azure/go-amqp"
 	. "github.com/onsi/ginkgo/v2"
@@ -280,5 +283,258 @@ var _ = Describe("AMQP publisher ", func() {
 		Expect(connection.Management().DeleteQueue(context.Background(), name)).To(BeNil())
 		Expect(connection.Close(context.Background())).To(BeNil())
 
+	})
+})
+
+var _ = Describe("AMQP publisher async", func() {
+	It("PublishAsync should send a message and invoke the callback with StateAccepted", func() {
+		qName := generateNameWithDateTime("PublishAsync should send and callback accepted")
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		Expect(connection).NotTo(BeNil())
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+
+		publisher, err := connection.NewPublisher(context.Background(), &QueueAddress{Queue: qName}, nil)
+		Expect(err).To(BeNil())
+		Expect(publisher).NotTo(BeNil())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var callbackResult *PublishResult
+		var callbackErr error
+
+		err = publisher.PublishAsync(context.Background(), NewMessage([]byte("hello async")),
+			func(result *PublishResult, cbErr error) {
+				defer wg.Done()
+				callbackResult = result
+				callbackErr = cbErr
+			})
+		Expect(err).To(BeNil())
+
+		wg.Wait()
+		Expect(callbackErr).To(BeNil())
+		Expect(callbackResult).NotTo(BeNil())
+		Expect(callbackResult.Outcome).To(Equal(&amqp.StateAccepted{}))
+
+		nMessages, err := connection.Management().PurgeQueue(context.Background(), qName)
+		Expect(err).To(BeNil())
+		Expect(nMessages).To(Equal(1))
+		Expect(publisher.Close(context.Background())).To(BeNil())
+		Expect(connection.Management().DeleteQueue(context.Background(), qName)).To(BeNil())
+		Expect(connection.Close(context.Background())).To(BeNil())
+	})
+
+	It("PublishAsync should send multiple messages and invoke all callbacks", func() {
+		qName := generateNameWithDateTime("PublishAsync should send multiple messages")
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+
+		publisher, err := connection.NewPublisher(context.Background(), &QueueAddress{Queue: qName}, nil)
+		Expect(err).To(BeNil())
+
+		totalMessages := 50
+		var wg sync.WaitGroup
+		wg.Add(totalMessages)
+		var accepted atomic.Int32
+
+		for i := 0; i < totalMessages; i++ {
+			err = publisher.PublishAsync(context.Background(), NewMessage([]byte("msg")),
+				func(result *PublishResult, cbErr error) {
+					defer wg.Done()
+					if cbErr == nil && result != nil {
+						if _, ok := result.Outcome.(*amqp.StateAccepted); ok {
+							accepted.Add(1)
+						}
+					}
+				})
+			Expect(err).To(BeNil())
+		}
+
+		wg.Wait()
+		Expect(int(accepted.Load())).To(Equal(totalMessages))
+
+		nMessages, err := connection.Management().PurgeQueue(context.Background(), qName)
+		Expect(err).To(BeNil())
+		Expect(nMessages).To(Equal(totalMessages))
+		Expect(publisher.Close(context.Background())).To(BeNil())
+		Expect(connection.Management().DeleteQueue(context.Background(), qName)).To(BeNil())
+		Expect(connection.Close(context.Background())).To(BeNil())
+	})
+
+	It("PublishAsync should respect MaxInFlight back-pressure", func() {
+		qName := generateNameWithDateTime("PublishAsync should respect MaxInFlight")
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+
+		maxInFlight := 5
+		publisher, err := connection.NewPublisher(context.Background(), &QueueAddress{Queue: qName},
+			&PublisherOptions{MaxInFlight: maxInFlight})
+		Expect(err).To(BeNil())
+
+		totalMessages := 20
+		var wg sync.WaitGroup
+		wg.Add(totalMessages)
+		var accepted atomic.Int32
+
+		for i := 0; i < totalMessages; i++ {
+			err = publisher.PublishAsync(context.Background(), NewMessage([]byte("msg")),
+				func(result *PublishResult, cbErr error) {
+					defer wg.Done()
+					if cbErr == nil && result != nil {
+						if _, ok := result.Outcome.(*amqp.StateAccepted); ok {
+							accepted.Add(1)
+						}
+					}
+				})
+			Expect(err).To(BeNil())
+		}
+
+		wg.Wait()
+		Expect(int(accepted.Load())).To(Equal(totalMessages))
+		Expect(publisher.Close(context.Background())).To(BeNil())
+		Expect(connection.Management().DeleteQueue(context.Background(), qName)).To(BeNil())
+		Expect(connection.Close(context.Background())).To(BeNil())
+	})
+
+	It("PublishAsync should return error when context is cancelled while waiting for in-flight slot", func() {
+		qName := generateNameWithDateTime("PublishAsync context cancelled on backpressure")
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+
+		// MaxInFlight = 1 so only one goroutine can be waiting at a time
+		publisher, err := connection.NewPublisher(context.Background(), &QueueAddress{Queue: qName},
+			&PublisherOptions{MaxInFlight: 1, PublishTimeout: 30 * time.Second})
+		Expect(err).To(BeNil())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		// Fill the single in-flight slot with a message whose callback blocks
+		blocker := make(chan struct{})
+		err = publisher.PublishAsync(context.Background(), NewMessage([]byte("blocker")),
+			func(result *PublishResult, cbErr error) {
+				defer wg.Done()
+				<-blocker // hold the slot
+			})
+		Expect(err).To(BeNil())
+
+		// Now try to publish with an already-cancelled context; should fail immediately
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err = publisher.PublishAsync(cancelledCtx, NewMessage([]byte("should fail")),
+			func(result *PublishResult, cbErr error) {})
+		Expect(err).NotTo(BeNil())
+		Expect(err).To(Equal(context.Canceled))
+
+		close(blocker)
+		wg.Wait()
+
+		Expect(publisher.Close(context.Background())).To(BeNil())
+		Expect(connection.Management().DeleteQueue(context.Background(), qName)).To(BeNil())
+		Expect(connection.Close(context.Background())).To(BeNil())
+	})
+
+	It("PublishAsync should fail with TO error for dynamic target without TO property", func() {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		publisher, err := connection.NewPublisher(context.Background(), nil, nil)
+		Expect(err).To(BeNil())
+
+		err = publisher.PublishAsync(context.Background(), NewMessage([]byte("hello")),
+			func(result *PublishResult, cbErr error) {})
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("message properties TO is required"))
+
+		Expect(connection.Close(context.Background())).To(BeNil())
+	})
+
+	It("PublishAsync callback should receive StateReleased for unroutable exchange message", func() {
+		eName := generateNameWithDateTime("PublishAsync released for unroutable")
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		_, err = connection.Management().DeclareExchange(context.Background(), &TopicExchangeSpecification{
+			Name:         eName,
+			IsAutoDelete: false,
+		})
+		Expect(err).To(BeNil())
+
+		publisher, err := connection.NewPublisher(context.Background(), &ExchangeAddress{
+			Exchange: eName,
+			Key:      "no-binding-key",
+		}, nil)
+		Expect(err).To(BeNil())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var callbackResult *PublishResult
+		var callbackErr error
+
+		err = publisher.PublishAsync(context.Background(), NewMessage([]byte("hello")),
+			func(result *PublishResult, cbErr error) {
+				defer wg.Done()
+				callbackResult = result
+				callbackErr = cbErr
+			})
+		Expect(err).To(BeNil())
+
+		wg.Wait()
+		Expect(callbackErr).To(BeNil())
+		Expect(callbackResult).NotTo(BeNil())
+		Expect(callbackResult.Outcome).To(Equal(&StateReleased{}))
+
+		Expect(connection.Management().DeleteExchange(context.Background(), eName)).To(BeNil())
+		Expect(connection.Close(context.Background())).To(BeNil())
+	})
+
+	It("PublishAsync with custom PublishTimeout should work", func() {
+		qName := generateNameWithDateTime("PublishAsync custom timeout")
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+
+		publisher, err := connection.NewPublisher(context.Background(), &QueueAddress{Queue: qName},
+			&PublisherOptions{PublishTimeout: 10 * time.Second})
+		Expect(err).To(BeNil())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var callbackResult *PublishResult
+		var callbackErr error
+
+		err = publisher.PublishAsync(context.Background(), NewMessage([]byte("hello timeout")),
+			func(result *PublishResult, cbErr error) {
+				defer wg.Done()
+				callbackResult = result
+				callbackErr = cbErr
+			})
+		Expect(err).To(BeNil())
+
+		wg.Wait()
+		Expect(callbackErr).To(BeNil())
+		Expect(callbackResult).NotTo(BeNil())
+		Expect(callbackResult.Outcome).To(Equal(&amqp.StateAccepted{}))
+
+		Expect(publisher.Close(context.Background())).To(BeNil())
+		Expect(connection.Management().DeleteQueue(context.Background(), qName)).To(BeNil())
+		Expect(connection.Close(context.Background())).To(BeNil())
 	})
 })

--- a/pkg/rabbitmqamqp/amqp_types.go
+++ b/pkg/rabbitmqamqp/amqp_types.go
@@ -2,6 +2,7 @@ package rabbitmqamqp
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Azure/go-amqp"
 	"github.com/google/uuid"
@@ -419,11 +420,34 @@ func (sco *StreamConsumerOptions) preSettled() bool {
 type IPublisherOptions interface {
 	linkName() string
 	id() string
+	maxInFlight() int
+	publishTimeout() time.Duration
 }
+
+// DefaultMaxInFlight is the default maximum number of pending PublishAsync goroutines.
+const DefaultMaxInFlight = 256
+
+// DefaultPublishTimeout is the default timeout for waiting on broker confirmation in PublishAsync.
+const DefaultPublishTimeout = 10 * time.Second
+
+// PublishAsyncCallback is the callback invoked when an async publish completes or fails.
+// On success, result is non-nil and err is nil.
+// On failure (timeout or send error), result is nil and err describes the failure.
+type PublishAsyncCallback func(result *PublishResult, err error)
 
 type PublisherOptions struct {
 	Id             string
 	SenderLinkName string
+
+	// MaxInFlight limits the number of concurrent pending PublishAsync operations.
+	// When the limit is reached, PublishAsync blocks until a slot becomes available.
+	// Defaults to DefaultMaxInFlight (256) if zero.
+	MaxInFlight int
+
+	// PublishTimeout is the maximum time to wait for broker confirmation
+	// in PublishAsync before the callback receives a timeout error.
+	// Defaults to DefaultPublishTimeout (30s) if zero.
+	PublishTimeout time.Duration
 }
 
 func (apo *PublisherOptions) linkName() string {
@@ -432,4 +456,18 @@ func (apo *PublisherOptions) linkName() string {
 
 func (apo *PublisherOptions) id() string {
 	return apo.Id
+}
+
+func (apo *PublisherOptions) maxInFlight() int {
+	if apo == nil || apo.MaxInFlight <= 0 {
+		return DefaultMaxInFlight
+	}
+	return apo.MaxInFlight
+}
+
+func (apo *PublisherOptions) publishTimeout() time.Duration {
+	if apo == nil || apo.PublishTimeout <= 0 {
+		return DefaultPublishTimeout
+	}
+	return apo.PublishTimeout
 }

--- a/pkg/rabbitmqamqp/amqp_types.go
+++ b/pkg/rabbitmqamqp/amqp_types.go
@@ -430,9 +430,11 @@ const DefaultMaxInFlight = 256
 // DefaultPublishTimeout is the default timeout for waiting on broker confirmation in PublishAsync.
 const DefaultPublishTimeout = 10 * time.Second
 
-// PublishAsyncCallback is the callback invoked when an async publish completes or fails.
+// PublishAsyncCallback is the callback invoked when an async publish completes or
+// when waiting for broker confirmation fails.
 // On success, result is non-nil and err is nil.
-// On failure (timeout or send error), result is nil and err describes the failure.
+// On failure (for example, timeout or confirmation-wait error), result is nil and
+// err describes the failure.
 type PublishAsyncCallback func(result *PublishResult, err error)
 
 type PublisherOptions struct {

--- a/pkg/rabbitmqamqp/amqp_types.go
+++ b/pkg/rabbitmqamqp/amqp_types.go
@@ -442,11 +442,12 @@ type PublisherOptions struct {
 	// MaxInFlight limits the number of concurrent pending PublishAsync operations.
 	// When the limit is reached, PublishAsync blocks until a slot becomes available.
 	// Defaults to DefaultMaxInFlight (256) if zero.
+	// MaxInFlight could be the number of go-routines executed.
 	MaxInFlight int
 
 	// PublishTimeout is the maximum time to wait for broker confirmation
 	// in PublishAsync before the callback receives a timeout error.
-	// Defaults to DefaultPublishTimeout (30s) if zero.
+	// Defaults to DefaultPublishTimeout (10s) if zero.
 	PublishTimeout time.Duration
 }
 

--- a/pkg/rabbitmqamqp/life_cycle.go
+++ b/pkg/rabbitmqamqp/life_cycle.go
@@ -5,6 +5,15 @@ import (
 	"sync"
 )
 
+const (
+	open         = iota
+	reconnecting = iota
+	closing      = iota
+	closed       = iota
+)
+
+// ILifeCycleState defines the connection state
+// see the iota constants for possible states: open, reconnecting, closing, closed
 type ILifeCycleState interface {
 	getState() int
 }
@@ -42,13 +51,6 @@ func (c *StateClosed) getState() int {
 	return closed
 }
 
-const (
-	open         = iota
-	reconnecting = iota
-	closing      = iota
-	closed       = iota
-)
-
 func statusToString(status ILifeCycleState) string {
 	switch status.getState() {
 	case open:
@@ -64,6 +66,38 @@ func statusToString(status ILifeCycleState) string {
 
 }
 
+// StateChanged define the connection life cycle
+// See ILifeCycleState for more details about the possible states
+// Every time the connection state changes,
+// a StateChanged struct is sent to the channel defined in LifeCycle.notifyStatusChange method.
+// You can use it to manage your connection and react to the state changes, for example,
+// by blocking the publishing messages during the reconnection, ex:
+// <code>
+//
+//	 signalBlock := sync.Cond{L: &sync.Mutex{}}
+//		stateChanged := make(chan *rmq.StateChanged, 1)
+//		go func(ch chan *rmq.StateChanged) {
+//			for statusChanged := range ch {
+//				rmq.Info("[connection]", "Status changed", statusChanged)
+//				switch statusChanged.To.(type) {
+//				case *rmq.StateOpen:
+//					signalBlock.Broadcast()
+//				case *rmq.StateReconnecting:
+//					rmq.Info("[connection]", "Reconnecting to the AMQP 1.0 server")
+//				case *rmq.StateClosed:
+//					StateClosed := statusChanged.To.(*rmq.StateClosed)
+//					if errors.Is(StateClosed.GetError(), rmq.ErrMaxReconnectAttemptsReached) {
+//						rmq.Error("[connection]", "Max reconnect attempts reached. Closing connection", StateClosed.GetError())
+//						signalBlock.Broadcast()
+//						isRunning = false
+//					}
+//
+//				}
+//			}
+//		}(stateChanged)
+//
+// </code>
+// see examples/reliable/reliable.go example for more details.
 type StateChanged struct {
 	From ILifeCycleState
 	To   ILifeCycleState

--- a/pkg/rabbitmqamqp/life_cycle.go
+++ b/pkg/rabbitmqamqp/life_cycle.go
@@ -66,13 +66,13 @@ func statusToString(status ILifeCycleState) string {
 
 }
 
-// StateChanged define the connection life cycle
-// See ILifeCycleState for more details about the possible states
+// StateChanged defines the connection life cycle.
+// See ILifeCycleState for more details about the possible states.
 // Every time the connection state changes,
-// a StateChanged struct is sent to the channel defined in LifeCycle.notifyStatusChange method.
-// You can use it to manage your connection and react to the state changes, for example,
-// by blocking the publishing messages during the reconnection, ex:
-// <code>
+// a StateChanged struct is sent to the channel defined in the
+// LifeCycle.notifyStatusChange method.
+// You can use it to manage your connection and react to state changes, e.g.
+// by blocking message publishing during reconnection:
 //
 //	 signalBlock := sync.Cond{L: &sync.Mutex{}}
 //		stateChanged := make(chan *rmq.StateChanged, 1)


### PR DESCRIPTION
Introduce PublishAsync(ctx, message, callback) on Publisher as a fire-and-forget alternative to Publish. The send itself is synchronous (SendWithReceipt), but the broker-confirmation wait (SendReceipt.Wait) runs in a background goroutine and delivers its outcome via a PublishAsyncCallback.

Back-pressure is enforced through a channel-based semaphore (inFlight) whose capacity is controlled by PublisherOptions.MaxInFlight (default 256): PublishAsync blocks the caller until a slot is available or the context is cancelled. Each confirmation goroutine respects a configurable PublishTimeout (default 10 s) before surfacing a timeout error through the callback.

Also add integration tests covering the happy path, bulk sending, MaxInFlight throttling, context-cancellation back-pressure, validation errors, StateReleased outcomes, and custom timeouts, together with a runnable example in docs/examples/publish_async/.