### PR TITLE
feat(consumer): quorum SAC notifications via FLOW rabbitmq:active

### DIFF
--- a/.ci/ubuntu/gha-setup.sh
+++ b/.ci/ubuntu/gha-setup.sh
@@ -7,7 +7,7 @@ set -o xtrace
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly script_dir
 echo "[INFO] script_dir: '$script_dir'"
-readonly rabbitmq_image=${RABBITMQ_IMAGE:-rabbitmq:4.2-management-alpine}
+readonly rabbitmq_image=${RABBITMQ_IMAGE:-rabbitmq:4.3-rc-management}
 
 readonly docker_name_prefix='rabbitmq-amqp-go-client'
 readonly docker_network_name="$docker_name_prefix-network"

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -2,6 +2,7 @@
 
 
 - [Getting Started](getting_started) - A simple example to get you started.
+- [Quorum single-active-consumer notification](qq_single_active_notification) - Quorum queue SAC: FLOW link-state `rabbitmq:active` via `ConsumerOptions.SingleActiveConsumerStateChanged` (RabbitMQ 4.3+). Mirrors the [.NET QQSingleActiveNotification example](https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client/blob/main/docs/Examples/QQSingleActiveNotification/Program.cs).
 - [JMS queue](jms_queue) - Same flow as getting started, using `JMSQueueSpecification` (Tanzu RabbitMQ 4.3+).
 - [Delayed queue](delayed_queue) - Same flow as getting started, using `DelayedQueueSpecification` (Tanzu RabbitMQ 4.x).
 - [Reliable](reliable) - An example of how to deal with reconnections and error handling.

--- a/docs/examples/qq_single_active_notification/main.go
+++ b/docs/examples/qq_single_active_notification/main.go
@@ -1,0 +1,189 @@
+// RabbitMQ AMQP 1.0 Go Client: https://github.com/rabbitmq/rabbitmq-amqp-go-client
+// Quorum queue + Single Active Consumer: FLOW link-state notifications (rabbitmq:active)
+// via ConsumerOptions.SingleActiveConsumerStateChanged (RabbitMQ 4.3+).
+//
+//
+//	Usage: go run . <producer|consumer>
+//
+// Example:
+//
+//	Terminal 1: go run . consumer
+//	Terminal 2: go run . producer
+//
+// Run more than one consumer to see standby vs active notifications when the active consumer stops.
+//
+// Example path: https://github.com/rabbitmq/rabbitmq-amqp-go-client/tree/main/docs/examples/qq_single_active_notification/main.go
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
+)
+
+const (
+	defaultQueueName = "demo-qq-sac-notification"
+	defaultAMQPURL   = "amqp://guest:guest@localhost:5672/"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+	mode := strings.ToLower(strings.TrimSpace(os.Args[1]))
+	switch mode {
+	case "producer":
+		runProducer()
+	case "consumer":
+		runConsumer()
+	default:
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: go run . <producer|consumer>")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "  producer  — declare quorum queue (single-active-consumer) and publish messages")
+	fmt.Fprintln(os.Stderr, "  consumer  — declare the same queue and consume; logs SAC active/standby state")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Requires RabbitMQ 4.3+ for SingleActiveConsumerStateChanged.")
+}
+
+func amqpURL() string {
+	if u := strings.TrimSpace(os.Getenv("AMQP_URL")); u != "" {
+		return u
+	}
+	return defaultAMQPURL
+}
+
+func declareSACQueue(ctx context.Context, management *rmq.AmqpManagement) error {
+	_, err := management.DeclareQueue(ctx, &rmq.QuorumQueueSpecification{
+		Name:                 defaultQueueName,
+		SingleActiveConsumer: true,
+	})
+	return err
+}
+
+func runProducer() {
+	ctx := context.Background()
+	conn, err := rmq.Dial(ctx, amqpURL(), nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	defer conn.Close(ctx)
+
+	if err := declareSACQueue(ctx, conn.Management()); err != nil {
+		fmt.Fprintln(os.Stderr, "declare queue:", err)
+		os.Exit(1)
+	}
+	rmq.Info("Queue declared (quorum, single-active-consumer)", "queue", defaultQueueName)
+
+	pub, err := conn.NewPublisher(ctx, &rmq.QueueAddress{Queue: defaultQueueName}, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "publisher:", err)
+		os.Exit(1)
+	}
+	defer pub.Close(ctx)
+
+	const total = 3000
+	for i := 0; i < total; i++ {
+		time.Sleep(500 * time.Millisecond)
+		body := []byte(fmt.Sprintf("SAC demo message #%d", i))
+		res, err := pub.Publish(ctx, rmq.NewMessage(body))
+		if err != nil {
+			rmq.Error("publish failed", "error", err)
+			continue
+		}
+		switch res.Outcome.(type) {
+		case *rmq.StateAccepted:
+			rmq.Info("[Producer] published and confirmed", "message", string(body))
+		case *rmq.StateReleased:
+			rmq.Info("[Producer] released (not routed)", "message", string(body))
+		case *rmq.StateRejected:
+			rmq.Error("[Producer] rejected", "message", string(body))
+		default:
+			rmq.Warn("[Producer] unexpected outcome", "outcome", fmt.Sprintf("%T", res.Outcome))
+		}
+	}
+	rmq.Info("Producer finished publishing.")
+}
+
+func runConsumer() {
+	ctx := context.Background()
+	conn, err := rmq.Dial(ctx, amqpURL(), nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	defer conn.Close(ctx)
+
+	if err := declareSACQueue(ctx, conn.Management()); err != nil {
+		fmt.Fprintln(os.Stderr, "declare queue:", err)
+		os.Exit(1)
+	}
+	rmq.Info("Queue declared (quorum, single-active-consumer)", "queue", defaultQueueName)
+
+	consumer, err := conn.NewConsumer(ctx, defaultQueueName, &rmq.ConsumerOptions{
+		SettleStrategy: rmq.ExplicitSettle,
+		SingleActiveConsumerStateChanged: func(_ *rmq.Consumer, isActive bool) {
+			writeSacNotification(isActive)
+		},
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "consumer:", err)
+		os.Exit(1)
+	}
+	defer consumer.Close(ctx)
+
+	recvCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		for {
+			dc, err := consumer.Receive(recvCtx)
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			if err != nil {
+				rmq.Error("[Consumer] receive error", "error", err)
+				return
+			}
+			msg := dc.Message()
+			body := ""
+			if len(msg.Data) > 0 {
+				body = string(msg.Data[0])
+			}
+			rmq.Info("[Consumer] received", "message", body)
+			if err := dc.Accept(ctx); err != nil {
+				rmq.Error("[Consumer] accept error", "error", err)
+				return
+			}
+		}
+	}()
+
+	fmt.Println("Consumer running. SingleActiveConsumerStateChanged fires when the broker marks this link active or standby (RabbitMQ 4.3+).")
+	fmt.Println("Press Enter to exit.")
+	_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+	cancel()
+}
+
+func writeSacNotification(isActive bool) {
+	state := "STANDBY"
+	if isActive {
+		state = "ACTIVE (this link delivers messages)"
+	}
+	fmt.Println("********************************")
+	fmt.Printf("[%s] Single Active Consumer state: %s\n", time.Now().Format("15:04:05.000"), state)
+	fmt.Println("********************************")
+}

--- a/pkg/rabbitmqamqp/amqp_consumer.go
+++ b/pkg/rabbitmqamqp/amqp_consumer.go
@@ -202,6 +202,73 @@ func (c *Consumer) Id() string {
 	return c.id
 }
 
+// rabbitmqActiveFromLinkState decodes broker FLOW link-state values for rabbitmq:active.
+func rabbitmqActiveFromLinkState(v any) (active bool, ok bool) {
+	switch t := v.(type) {
+	case bool:
+		return t, true
+	case int64:
+		return t != 0, true
+	case int32:
+		return t != 0, true
+	case int16:
+		return t != 0, true
+	case int8:
+		return t != 0, true
+	case int:
+		return t != 0, true
+	case uint64:
+		return t != 0, true
+	case uint32:
+		return t != 0, true
+	case uint16:
+		return t != 0, true
+	case uint8:
+		return t != 0, true
+	case uint:
+		return t != 0, true
+	case float64:
+		return t != 0, true
+	case float32:
+		return t != 0, true
+	default:
+		return false, false
+	}
+}
+
+func setSingleActiveConsumerLinkStateHandler(opts *amqp.ReceiverOptions, options IConsumerOptions, c *Consumer) {
+	if opts == nil || c == nil || options == nil {
+		return
+	}
+	co, ok := options.(*ConsumerOptions)
+	if !ok || co.SingleActiveConsumerStateChanged == nil {
+		return
+	}
+	handler := co.SingleActiveConsumerStateChanged
+	opts.OnLinkStateProperties = func(props map[string]any) {
+		if len(props) == 0 {
+			return
+		}
+		v, has := props[rabbitmqActiveLinkStateProperty]
+		if !has {
+			return
+		}
+		active, parsed := rabbitmqActiveFromLinkState(v)
+		if !parsed {
+			Warn("Ignoring rabbitmq:active with unsupported type", "value", v)
+			return
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					Error("SingleActiveConsumerStateChanged handler panicked", "recover", r)
+				}
+			}()
+			handler(c, active)
+		}()
+	}
+}
+
 func newConsumer(ctx context.Context, connection *AmqpConnection, destinationAdd string, options IConsumerOptions) (*Consumer, error) {
 	id := fmt.Sprintf("consumer-%s", uuid.New().String())
 	if options != nil && options.id() != "" {
@@ -260,6 +327,7 @@ func (c *Consumer) createReceiver(ctx context.Context) error {
 		// normal receiver link, inside createReceiverLinkOptions we check if pre-settled mode is enabled
 		// so, by default we use AtLeastOnce settlement mode even is not specified
 		receiverOptions = createReceiverLinkOptions(c.destinationAdd, c.options, AtLeastOnce)
+		setSingleActiveConsumerLinkStateHandler(receiverOptions, c.options, c)
 	}
 
 	receiver, err := c.connection.session.NewReceiver(ctx, c.destinationAdd, receiverOptions)

--- a/pkg/rabbitmqamqp/amqp_consumer_test.go
+++ b/pkg/rabbitmqamqp/amqp_consumer_test.go
@@ -3,6 +3,7 @@ package rabbitmqamqp
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/Azure/go-amqp"
 	. "github.com/onsi/ginkgo/v2"
@@ -360,6 +361,85 @@ var _ = Describe("Consumer pre-settled", func() {
 	})
 })
 
+var _ = Describe("Quorum single-active-consumer link state", func() {
+	It("notifies standby then promotion when the active consumer closes", func() {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		ver, _ := connection.Properties()["version"].(string)
+		if !isVersionGreaterOrEqual(extractVersion(ver), "4.3.0") {
+			Skip("requires RabbitMQ 4.3+ for quorum SAC FLOW link-state")
+		}
+		qName := generateNameWithDateTime("qq_sac_flow")
+		DeferCleanup(func() {
+			_ = connection.Management().DeleteQueue(context.Background(), qName)
+			_ = connection.Close(context.Background())
+		})
+
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name:                 qName,
+			SingleActiveConsumer: true,
+		})
+		Expect(err).To(BeNil())
+
+		c1, err := connection.NewConsumer(context.Background(), qName, &ConsumerOptions{SettleStrategy: ExplicitSettle})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = c1.Close(context.Background()) })
+
+		var mu sync.Mutex
+		var c2States []bool
+		c2, err := connection.NewConsumer(context.Background(), qName, &ConsumerOptions{
+			SettleStrategy: ExplicitSettle,
+			SingleActiveConsumerStateChanged: func(_ *Consumer, active bool) {
+				mu.Lock()
+				c2States = append(c2States, active)
+				mu.Unlock()
+			},
+		})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = c2.Close(context.Background()) })
+
+		Eventually(func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			for _, s := range c2States {
+				if !s {
+					return true
+				}
+			}
+			return false
+		}).WithTimeout(5 * time.Second).WithPolling(50 * time.Millisecond).Should(BeTrue())
+
+		Expect(c1.Close(context.Background())).To(BeNil())
+
+		Eventually(func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			seenStandby := false
+			for _, s := range c2States {
+				if !s {
+					seenStandby = true
+				}
+				if seenStandby && s {
+					return true
+				}
+			}
+			return false
+		}).WithTimeout(5 * time.Second).WithPolling(50 * time.Millisecond).Should(BeTrue())
+	})
+
+	It("rejects DirectReplyTo when a SAC handler is configured", func() {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = connection.Close(context.Background()) })
+		_, err = connection.NewConsumer(context.Background(), "ignored", &ConsumerOptions{
+			SettleStrategy:                   DirectReplyTo,
+			SingleActiveConsumerStateChanged: func(*Consumer, bool) {},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("DirectReplyTo"))
+	})
+})
+
 var _ = Describe("streamOffsetFromAnnotation", func() {
 	DescribeTable("decodes stream offset annotations",
 		func(v any, want int64, wantOK bool) {
@@ -373,5 +453,22 @@ var _ = Describe("streamOffsetFromAnnotation", func() {
 		Entry("uint64 overflow", uint64(1<<63), int64(0), false),
 		Entry("string", "nope", int64(0), false),
 		Entry("nil", nil, int64(0), false),
+	)
+})
+
+var _ = Describe("rabbitmqActiveFromLinkState", func() {
+	DescribeTable("decodes rabbitmq:active values",
+		func(v any, want bool, wantOK bool) {
+			got, ok := rabbitmqActiveFromLinkState(v)
+			Expect(ok).To(Equal(wantOK))
+			Expect(got).To(Equal(want))
+		},
+		Entry("bool true", true, true, true),
+		Entry("bool false", false, false, true),
+		Entry("int64 non-zero", int64(1), true, true),
+		Entry("int64 zero", int64(0), false, true),
+		Entry("uint8", uint8(2), true, true),
+		Entry("float64", float64(1), true, true),
+		Entry("string", "x", false, false),
 	)
 })

--- a/pkg/rabbitmqamqp/amqp_types.go
+++ b/pkg/rabbitmqamqp/amqp_types.go
@@ -142,6 +142,11 @@ type ConsumerOptions struct {
 	// SettleStrategy configures how messages are received and settled.
 	// See ConsumerSettleStrategy for more details.
 	SettleStrategy ConsumerSettleStrategy
+
+	// SingleActiveConsumerStateChanged, when non-nil, registers for FLOW link-state
+	// updates for rabbitmq:active on this consumer link. Use with a quorum queue
+	// declared using SingleActiveConsumer. See SingleActiveConsumerStateChangedFunc.
+	SingleActiveConsumerStateChanged SingleActiveConsumerStateChangedFunc
 }
 
 func (aco *ConsumerOptions) linkName() string {
@@ -164,6 +169,15 @@ func (aco *ConsumerOptions) validate(available *featuresAvailable) error {
 	// direct reply to is supported since RabbitMQ 4.2.0
 	if aco.SettleStrategy == DirectReplyTo && !available.is42rMore {
 		return fmt.Errorf("direct reply to feature is not supported. You need RabbitMQ 4.2 or later")
+	}
+
+	if aco.SingleActiveConsumerStateChanged != nil {
+		if aco.SettleStrategy == DirectReplyTo {
+			return fmt.Errorf("single active consumer state notification is not supported with DirectReplyTo settle strategy")
+		}
+		if !available.is43rMore {
+			return fmt.Errorf("single active consumer state notification requires RabbitMQ 4.3 or later")
+		}
 	}
 
 	return nil
@@ -193,6 +207,16 @@ const rmqStreamOffsetSpec = "rabbitmq:stream-offset-spec"
 const rmqStreamMatchUnfiltered = "rabbitmq:stream-match-unfiltered"
 const amqpApplicationPropertiesFilter = "amqp:application-properties-filter"
 const amqpPropertiesFilter = "amqp:properties-filter"
+
+// rabbitmqActiveLinkStateProperty is the FLOW link-state key RabbitMQ 4.3+ uses
+// for quorum queue single-active-consumer active (true) vs standby (false).
+const rabbitmqActiveLinkStateProperty = "rabbitmq:active"
+
+// SingleActiveConsumerStateChangedFunc is called when the broker reports quorum
+// single-active-consumer state via AMQP 1.0 FLOW link-state (rabbitmq:active).
+// Requires RabbitMQ 4.3+, a quorum queue declared with x-single-active-consumer,
+// and cannot be used together with DirectReplyTo.
+type SingleActiveConsumerStateChangedFunc func(consumer *Consumer, isActive bool)
 
 const offsetFirst = "first"
 const offsetNext = "next"

--- a/pkg/rabbitmqamqp/features_available_test.go
+++ b/pkg/rabbitmqamqp/features_available_test.go
@@ -2,6 +2,7 @@ package rabbitmqamqp
 
 import (
 	"fmt"
+
 	"github.com/Azure/go-amqp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -127,6 +128,23 @@ var _ = Describe("Available Features", func() {
 				},
 			},
 		}).validate(&featuresAvailable{is41OrMore: true})).To(BeNil())
+	})
+
+	It("ConsumerOptions validate for single active consumer state notification", func() {
+		nop := func(*Consumer, bool) {}
+
+		Expect((&ConsumerOptions{
+			SingleActiveConsumerStateChanged: nop,
+		}).validate(&featuresAvailable{is43rMore: false})).To(MatchError(ContainSubstring("4.3")))
+
+		Expect((&ConsumerOptions{
+			SettleStrategy:                   DirectReplyTo,
+			SingleActiveConsumerStateChanged: nop,
+		}).validate(&featuresAvailable{is43rMore: true, is42rMore: true})).To(MatchError(ContainSubstring("DirectReplyTo")))
+
+		Expect((&ConsumerOptions{
+			SingleActiveConsumerStateChanged: nop,
+		}).validate(&featuresAvailable{is43rMore: true})).To(BeNil())
 	})
 
 })


### PR DESCRIPTION
Register OnLinkStateProperties on the AMQP receiver when ConsumerOptions.SingleActiveConsumerStateChanged is set, and invoke the callback from FLOW link-state rabbitmq:active (RabbitMQ 4.3+).

Validate: require 4.3+, disallow combining with DirectReplyTo.

Add unit/integration tests, docs example qq_single_active_notification