### PR TITLE
feat(queue): support quorum queue delayed retry (RabbitMQ 4.3+)

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -18,3 +18,4 @@
 - [Web Sockets](web_sockets) - An example of how to use Web Sockets with the AMQP 1.0 client.
 - [Pre-settled messages](pre_settled) - An example of how to receive pre-settled messages with the AMQP 1.0 client.
 - [Reject a message with a Reason](rejected_by_reason) - An example of reject with rejected-by and rejection reason (RabbitMQ 4.3+) 
+- [Quorum Queue Delayed Retry](qq_delayed_retry) - An example of how to use linear back-off redelivery on quorum queues (RabbitMQ 4.3+)

--- a/docs/examples/qq_delayed_retry/main.go
+++ b/docs/examples/qq_delayed_retry/main.go
@@ -1,0 +1,167 @@
+// RabbitMQ AMQP 1.0 Go Client: https://github.com/rabbitmq/rabbitmq-amqp-go-client
+// RabbitMQ AMQP 1.0 documentation: https://www.rabbitmq.com/docs/amqp
+// This example demonstrates quorum queue delayed retry (linear back-off redelivery),
+// available as of RabbitMQ 4.3. The three queue arguments x-delayed-retry-type,
+// x-delayed-retry-min, and x-delayed-retry-max are set via QuorumQueueSpecification.
+// example path: https://github.com/rabbitmq/rabbitmq-amqp-go-client/tree/main/docs/examples/qq_delayed_retry/main.go
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
+)
+
+func main() {
+	queueName := "qq-delayed-retry-go-queue"
+
+	rmq.Info("Quorum queue delayed retry example with AMQP Go AMQP 1.0 Client")
+
+	stateChanged := make(chan *rmq.StateChanged, 1)
+	go func(ch chan *rmq.StateChanged) {
+		for statusChanged := range ch {
+			rmq.Info("[connection]", "Status changed", statusChanged)
+		}
+	}(stateChanged)
+
+	env := rmq.NewEnvironment("amqp://guest:guest@localhost:5672/", nil)
+
+	amqpConnection, err := env.NewConnection(context.TODO())
+	if err != nil {
+		rmq.Error("Error opening connection", err)
+		return
+	}
+	amqpConnection.NotifyStatusChange(stateChanged)
+
+	rmq.Info("AMQP connection opened")
+	management := amqpConnection.Management()
+
+	// Declare a quorum queue with delayed retry (requires RabbitMQ 4.3+).
+	// - DelayedRetryType: controls which messages trigger linear back-off redelivery.
+	//   Use QuorumQueueDelayedRetryReturned so only messages returned (nacked) by
+	//   consumers are retried with a delay, rather than all redeliveries.
+	// - DelayedRetryMin: minimum back-off delay before the first retry.
+	// - DelayedRetryMax: upper bound for the back-off delay.
+	queueInfo, err := management.DeclareQueue(context.TODO(), &rmq.QuorumQueueSpecification{
+		Name:             queueName,
+		DeliveryLimit:    5,
+		DelayedRetryType: rmq.QuorumQueueDelayedRetryReturned,
+		DelayedRetryMin:  2 * time.Second,
+		DelayedRetryMax:  30 * time.Second,
+	})
+	if err != nil {
+		rmq.Error("Error declaring queue", err)
+		return
+	}
+	rmq.Info("Queue declared", "name", queueInfo.Name())
+
+	consumer, err := amqpConnection.NewConsumer(context.TODO(), queueName, nil)
+	if err != nil {
+		rmq.Error("Error creating consumer", err)
+		return
+	}
+
+	consumerContext, cancel := context.WithCancel(context.TODO())
+
+	received := make(chan struct{}, 10)
+	counter := int32(0)
+	go func(ctx context.Context) {
+		for {
+			deliveryContext, err := consumer.Receive(ctx)
+			if errors.Is(err, context.Canceled) {
+				rmq.Info("[Consumer] Consumer closed")
+				return
+			}
+			if err != nil {
+				rmq.Error("[Consumer] Error receiving message", "error", err)
+				return
+			}
+
+			if atomic.AddInt32(&counter, 1) < 10 {
+				rmq.Warn("[Consumer] Simulating processing failure, message will be retried with delay 2s", "message",
+					fmt.Sprintf("%s", deliveryContext.Message().Data))
+				err = deliveryContext.Requeue(context.TODO())
+				if err != nil {
+					rmq.Error("[Consumer] Error requeuing message", "error", err)
+					return
+				}
+			} else {
+				rmq.Info("[Consumer] Received message", "message",
+					fmt.Sprintf("%s", deliveryContext.Message().Data))
+
+				err = deliveryContext.Accept(context.TODO())
+				if err != nil {
+					rmq.Error("[Consumer] Error accepting message", "error", err)
+					return
+				}
+				received <- struct{}{}
+			}
+		}
+	}(consumerContext)
+
+	publisher, err := amqpConnection.NewPublisher(context.TODO(), &rmq.QueueAddress{Queue: queueName}, nil)
+	if err != nil {
+		rmq.Error("Error creating publisher", err)
+		return
+	}
+
+	const msgCount = 5
+	for i := 0; i < msgCount; i++ {
+		publishResult, err := publisher.Publish(context.TODO(),
+			rmq.NewMessage([]byte(fmt.Sprintf("Hello delayed-retry #%d", i))))
+		if err != nil {
+			rmq.Error("Error publishing message", "error", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		switch publishResult.Outcome.(type) {
+		case *rmq.StateAccepted:
+			rmq.Info("[Publisher] Message accepted", "index", i)
+		case *rmq.StateReleased:
+			rmq.Warn("[Publisher] Message was not routed", "index", i)
+		case *rmq.StateRejected:
+			rmq.Warn("[Publisher] Message rejected", "index", i)
+		default:
+			rmq.Warn("[Publisher] Unknown outcome", "outcome", publishResult.Outcome)
+		}
+	}
+
+	// Wait until all messages are consumed.
+	for i := 0; i < msgCount; i++ {
+		<-received
+	}
+
+	cancel()
+	err = consumer.Close(context.TODO())
+	if err != nil {
+		rmq.Error("[Consumer] Error closing consumer", err)
+		return
+	}
+
+	err = publisher.Close(context.TODO())
+	if err != nil {
+		rmq.Error("[Publisher] Error closing publisher", err)
+		return
+	}
+
+	err = management.DeleteQueue(context.TODO(), queueInfo.Name())
+	if err != nil {
+		rmq.Error("Error deleting queue", "error", err)
+		return
+	}
+
+	err = env.CloseConnections(context.TODO())
+	if err != nil {
+		rmq.Error("Error closing connection", "error", err)
+		return
+	}
+
+	rmq.Info("AMQP connection closed")
+	time.Sleep(100 * time.Millisecond)
+	close(stateChanged)
+}

--- a/docs/examples/qq_delayed_retry/main.go
+++ b/docs/examples/qq_delayed_retry/main.go
@@ -45,14 +45,14 @@ func main() {
 	// - DelayedRetryType: controls which messages trigger linear back-off redelivery.
 	//   Use QuorumQueueDelayedRetryReturned so only messages returned (nacked) by
 	//   consumers are retried with a delay, rather than all redeliveries.
-	// - DelayedRetryMin: minimum back-off delay before the first retry.
+	// - DelayedRetryMin: minimum back-off delay before the first retry. (valid for Failure)
 	// - DelayedRetryMax: upper bound for the back-off delay.
 	queueInfo, err := management.DeclareQueue(context.TODO(), &rmq.QuorumQueueSpecification{
-		Name:             queueName,
-		DeliveryLimit:    5,
+		Name: queueName,
+		//DeliveryLimit:    5,
 		DelayedRetryType: rmq.QuorumQueueDelayedRetryReturned,
 		DelayedRetryMin:  2 * time.Second,
-		DelayedRetryMax:  30 * time.Second,
+		//DelayedRetryMax:  30 * time.Second,
 	})
 	if err != nil {
 		rmq.Error("Error declaring queue", err)

--- a/pkg/rabbitmqamqp/amqp_queue_test.go
+++ b/pkg/rabbitmqamqp/amqp_queue_test.go
@@ -3,6 +3,7 @@ package rabbitmqamqp
 import (
 	"context"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -263,6 +264,42 @@ var _ = Describe("AMQP Queue test ", func() {
 		})
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("DelayedQueueSpecification is only supported on Tanzu RabbitMQ"))
+	})
+
+	It("AMQP Declare Quorum Queue with delayed retry should succeed on RabbitMQ 4.3+", func() {
+		if !connection.featuresAvailable.is43rMore {
+			Skip("Requires RabbitMQ 4.3 or later")
+		}
+		queueName := generateName("AMQP Declare Quorum Queue with delayed retry")
+		queueInfo, err := management.DeclareQueue(context.TODO(), &QuorumQueueSpecification{
+			Name:             queueName,
+			DelayedRetryType: QuorumQueueDelayedRetryReturned,
+			DelayedRetryMin:  2 * time.Second,
+			DelayedRetryMax:  60 * time.Second,
+		})
+		Expect(err).To(BeNil())
+		Expect(queueInfo).NotTo(BeNil())
+		Expect(queueInfo.Name()).To(Equal(queueName))
+		Expect(queueInfo.Type()).To(Equal(Quorum))
+		Expect(queueInfo.Arguments()).To(HaveKeyWithValue("x-delayed-retry-type", "returned"))
+		Expect(queueInfo.Arguments()).To(HaveKeyWithValue("x-delayed-retry-min", int64(2000)))
+		Expect(queueInfo.Arguments()).To(HaveKeyWithValue("x-delayed-retry-max", int64(60000)))
+
+		err = management.DeleteQueue(context.TODO(), queueName)
+		Expect(err).To(BeNil())
+	})
+
+	It("AMQP Declare Quorum Queue with delayed retry should fail on RabbitMQ < 4.3", func() {
+		if connection.featuresAvailable.is43rMore {
+			Skip("Only fails on RabbitMQ < 4.3")
+		}
+		queueName := generateName("AMQP Declare Quorum Queue with delayed retry should fail")
+		_, err := management.DeclareQueue(context.TODO(), &QuorumQueueSpecification{
+			Name:             queueName,
+			DelayedRetryType: QuorumQueueDelayedRetryReturned,
+		})
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("4.3"))
 	})
 
 	// default

--- a/pkg/rabbitmqamqp/entities.go
+++ b/pkg/rabbitmqamqp/entities.go
@@ -5,6 +5,17 @@ import (
 	"time"
 )
 
+// QuorumQueueDelayedRetryType controls the x-delayed-retry-type queue argument for quorum queues.
+// This feature requires RabbitMQ 4.3 or later.
+type QuorumQueueDelayedRetryType string
+
+const (
+	// QuorumQueueDelayedRetryDisabled disables delayed retry redelivery.
+	QuorumQueueDelayedRetryDisabled QuorumQueueDelayedRetryType = "disabled"
+	// QuorumQueueDelayedRetryReturned enables delayed retry only for messages returned by consumers.
+	QuorumQueueDelayedRetryReturned QuorumQueueDelayedRetryType = "returned"
+)
+
 type iEntityIdentifier interface {
 	Id() string
 }
@@ -193,7 +204,16 @@ type QuorumQueueSpecification struct {
 	TargetClusterSize      int64
 	LeaderLocator          ILeaderLocator
 	QuorumInitialGroupSize int
-	Arguments              map[string]any
+	// DelayedRetryType enables linear back-off redelivery on the quorum queue.
+	// Requires RabbitMQ 4.3 or later. Maps to the x-delayed-retry-type queue argument.
+	DelayedRetryType QuorumQueueDelayedRetryType
+	// DelayedRetryMin is the minimum delay before a message is redelivered.
+	// Requires RabbitMQ 4.3 or later. Maps to the x-delayed-retry-min queue argument (milliseconds).
+	DelayedRetryMin time.Duration
+	// DelayedRetryMax is the maximum delay before a message is redelivered.
+	// Requires RabbitMQ 4.3 or later. Maps to the x-delayed-retry-max queue argument (milliseconds).
+	DelayedRetryMax time.Duration
+	Arguments       map[string]any
 }
 
 func (q *QuorumQueueSpecification) name() string {
@@ -266,11 +286,28 @@ func (q *QuorumQueueSpecification) buildArguments() map[string]any {
 		result["x-quorum-initial-group-size"] = q.QuorumInitialGroupSize
 	}
 
+	if len(q.DelayedRetryType) != 0 {
+		result["x-delayed-retry-type"] = string(q.DelayedRetryType)
+	}
+
+	if q.DelayedRetryMin != 0 {
+		result["x-delayed-retry-min"] = q.DelayedRetryMin.Milliseconds()
+	}
+
+	if q.DelayedRetryMax != 0 {
+		result["x-delayed-retry-max"] = q.DelayedRetryMax.Milliseconds()
+	}
+
 	result["x-queue-type"] = string(q.queueType())
 	return result
 }
 
-func (q *QuorumQueueSpecification) validate(*featuresAvailable) error {
+func (q *QuorumQueueSpecification) validate(f *featuresAvailable) error {
+	if f != nil && (len(q.DelayedRetryType) != 0 || q.DelayedRetryMin != 0 || q.DelayedRetryMax != 0) {
+		if !f.is43rMore {
+			return fmt.Errorf("QuorumQueueSpecification delayed retry fields require RabbitMQ 4.3 or later")
+		}
+	}
 	return nil
 }
 

--- a/pkg/rabbitmqamqp/entities_test.go
+++ b/pkg/rabbitmqamqp/entities_test.go
@@ -282,6 +282,103 @@ var _ = Describe("Entities", func() {
 		})
 	})
 
+	Describe("QuorumQueueSpecification delayed retry", func() {
+		It("should set x-delayed-retry-type when DelayedRetryType is set", func() {
+			spec := &QuorumQueueSpecification{
+				Name:             "my-qq",
+				DelayedRetryType: QuorumQueueDelayedRetryReturned,
+			}
+			args := spec.buildArguments()
+			Expect(args["x-delayed-retry-type"]).To(Equal("returned"))
+		})
+
+		It("should set x-delayed-retry-type to disabled", func() {
+			spec := &QuorumQueueSpecification{
+				Name:             "my-qq",
+				DelayedRetryType: QuorumQueueDelayedRetryDisabled,
+			}
+			args := spec.buildArguments()
+			Expect(args["x-delayed-retry-type"]).To(Equal("disabled"))
+		})
+
+		It("should not set x-delayed-retry-type when DelayedRetryType is empty", func() {
+			spec := &QuorumQueueSpecification{Name: "my-qq"}
+			args := spec.buildArguments()
+			Expect(args).ToNot(HaveKey("x-delayed-retry-type"))
+		})
+
+		It("should set x-delayed-retry-min in milliseconds when DelayedRetryMin is set", func() {
+			spec := &QuorumQueueSpecification{
+				Name:            "my-qq",
+				DelayedRetryMin: 5 * time.Second,
+			}
+			args := spec.buildArguments()
+			Expect(args["x-delayed-retry-min"]).To(Equal(int64(5000)))
+		})
+
+		It("should not set x-delayed-retry-min when DelayedRetryMin is zero", func() {
+			spec := &QuorumQueueSpecification{Name: "my-qq"}
+			args := spec.buildArguments()
+			Expect(args).ToNot(HaveKey("x-delayed-retry-min"))
+		})
+
+		It("should set x-delayed-retry-max in milliseconds when DelayedRetryMax is set", func() {
+			spec := &QuorumQueueSpecification{
+				Name:            "my-qq",
+				DelayedRetryMax: 30 * time.Second,
+			}
+			args := spec.buildArguments()
+			Expect(args["x-delayed-retry-max"]).To(Equal(int64(30000)))
+		})
+
+		It("should not set x-delayed-retry-max when DelayedRetryMax is zero", func() {
+			spec := &QuorumQueueSpecification{Name: "my-qq"}
+			args := spec.buildArguments()
+			Expect(args).ToNot(HaveKey("x-delayed-retry-max"))
+		})
+
+		It("should set all three delayed retry arguments together", func() {
+			spec := &QuorumQueueSpecification{
+				Name:             "my-qq",
+				DelayedRetryType: QuorumQueueDelayedRetryReturned,
+				DelayedRetryMin:  2 * time.Second,
+				DelayedRetryMax:  60 * time.Second,
+			}
+			args := spec.buildArguments()
+			Expect(args["x-delayed-retry-type"]).To(Equal("returned"))
+			Expect(args["x-delayed-retry-min"]).To(Equal(int64(2000)))
+			Expect(args["x-delayed-retry-max"]).To(Equal(int64(60000)))
+			Expect(args["x-queue-type"]).To(Equal("quorum"))
+		})
+
+		It("should fail validation when delayed retry fields are set on RabbitMQ < 4.3", func() {
+			spec := &QuorumQueueSpecification{
+				Name:             "my-qq",
+				DelayedRetryType: QuorumQueueDelayedRetryReturned,
+			}
+			err := spec.validate(&featuresAvailable{is43rMore: false})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("4.3"))
+		})
+
+		It("should pass validation when delayed retry fields are set on RabbitMQ >= 4.3", func() {
+			spec := &QuorumQueueSpecification{
+				Name:             "my-qq",
+				DelayedRetryType: QuorumQueueDelayedRetryReturned,
+				DelayedRetryMin:  2 * time.Second,
+				DelayedRetryMax:  60 * time.Second,
+			}
+			Expect(spec.validate(&featuresAvailable{is43rMore: true})).To(BeNil())
+		})
+
+		It("should pass validation when no delayed retry fields are set regardless of version", func() {
+			spec := &QuorumQueueSpecification{Name: "my-qq"}
+			Expect(spec.validate(&featuresAvailable{is43rMore: false})).To(BeNil())
+			Expect(spec.validate(&featuresAvailable{is43rMore: true})).To(BeNil())
+			Expect(spec.validate(nil)).To(BeNil())
+		})
+	})
+
 	Describe("durationToMaxAge", func() {
 		DescribeTable("converts duration to RabbitMQ max-age string",
 			func(d time.Duration, expected string) {


### PR DESCRIPTION
Add DelayedRetryType, DelayedRetryMin, and DelayedRetryMax to QuorumQueueSpecification, enabling linear back-off redelivery on quorum queues via the x-delayed-retry-type, x-delayed-retry-min, and x-delayed-retry-max queue arguments (available as of RabbitMQ 4.3).

A new QuorumQueueDelayedRetryType string type is introduced with two constants: QuorumQueueDelayedRetryDisabled and
QuorumQueueDelayedRetryReturned. The validate() method returns an error when any delayed retry field is set against a broker older than 4.3.

Includes unit tests, integration tests (skipped automatically on RabbitMQ < 4.3), and a runnable example under
docs/examples/qq_delayed_retry.