### PR TITLE
feat(consumer): add consumer timeout support for quorum and JMS queues

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -20,3 +20,6 @@
 - [Reject a message with a Reason](rejected_by_reason) - An example of reject with rejected-by and rejection reason (RabbitMQ 4.3+) 
 - [Quorum Queue Delayed Retry](qq_delayed_retry) - An example of redelivery on quorum queues (RabbitMQ 4.3+)
 - [Quorum Queue Delayed Retry - per-message delivery time](qq_delayed_retry_delivery_time) - An example of how to override the redelivery time per message using the `x-opt-delivery-time` annotation (RabbitMQ 4.3+)
+- [Quorum Queue Consumer Timeout](qq_consumer_timeout) - An example of quorum queue consumer timeouts (`x-consumer-timeout`) and how to handle the `OnDeliveryRelease` callback (RabbitMQ 4.3+)
+- [Publish Async](publish_async) - An example of how to use `PublishAsync` to send messages without blocking the caller while waiting for broker confirmation.
+- [OpenTelemetry Metrics](otel_metrics) - An example of how to configure OpenTelemetry metrics with a stdout exporter, showing connection, publisher, consumer, and message counts.

--- a/docs/examples/qq_consumer_timeout/main.go
+++ b/docs/examples/qq_consumer_timeout/main.go
@@ -1,0 +1,198 @@
+// RabbitMQ AMQP 1.0 Go Client: https://github.com/rabbitmq/rabbitmq-amqp-go-client
+// RabbitMQ AMQP 1.0 documentation: https://www.rabbitmq.com/docs/amqp
+// This example demonstrates quorum queue consumer timeouts (x-consumer-timeout).
+//
+// Consumer timeouts limit how long a consumer may hold a message without settling it
+// (accept / discard / requeue). When the timer fires, the broker sends a DISPOSITION
+// frame with Released state to the consumer, which triggers the OnDeliveryRelease callback.
+//
+// There are two levels of consumer timeout:
+//   - Queue-level: x-consumer-timeout queue argument (via QuorumQueueSpecification.ConsumerTimeout)
+//   - Consumer-level: rabbitmq:consumer-timeout AMQP attach property (via ConsumerOptions.ConsumerTimeout)
+//
+// The per-consumer setting takes precedence when both are configured.
+//
+// Inside OnDeliveryRelease, calling Accept() sends an AMQP Accepted disposition back to the
+// broker, unlocking the consumer so it can continue receiving messages. Discard and Requeue
+// are not valid in this context and will return ErrDeliveryReleaseInvalidOperation.
+//
+// Requires RabbitMQ 4.3 or later.
+// See: https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#consumer-timeouts
+// example path: https://github.com/rabbitmq/rabbitmq-amqp-go-client/tree/main/docs/examples/qq_consumer_timeout/main.go
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"github.com/Azure/go-amqp"
+	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
+)
+
+func main() {
+	queueName := "qq-consumer-timeout-go-example"
+
+	rmq.Info("Quorum queue consumer timeout example (RabbitMQ 4.3+)")
+
+	stateChanged := make(chan *rmq.StateChanged, 1)
+	go func(ch chan *rmq.StateChanged) {
+		for statusChanged := range ch {
+			rmq.Info("[connection]", "status changed", statusChanged)
+		}
+	}(stateChanged)
+
+	env := rmq.NewEnvironment("amqp://guest:guest@localhost:5672/", nil)
+
+	conn, err := env.NewConnection(context.Background())
+	if err != nil {
+		rmq.Error("Error opening connection", err)
+		return
+	}
+	conn.NotifyStatusChange(stateChanged)
+	defer func() {
+		_ = env.CloseConnections(context.Background())
+		close(stateChanged)
+	}()
+
+	rmq.Info("AMQP connection opened")
+	management := conn.Management()
+
+	// 1. Declare a quorum queue with a queue-level consumer timeout of 5 seconds.
+	//    This means any consumer that holds a message for more than 5 s will be timed out.
+	consumerTimeout := 5 * time.Second
+	queueInfo, err := management.DeclareQueue(context.Background(), &rmq.QuorumQueueSpecification{
+		Name:            queueName,
+		ConsumerTimeout: consumerTimeout,
+	})
+	if err != nil {
+		rmq.Error("Error declaring queue", err)
+		return
+	}
+	rmq.Info("Queue declared", "name", queueInfo.Name(), "x-consumer-timeout", consumerTimeout)
+
+	// 2. Publish a single message that will be used to trigger the timeout scenario.
+	publisher, err := conn.NewPublisher(context.Background(), &rmq.QueueAddress{Queue: queueName}, nil)
+	if err != nil {
+		rmq.Error("Error creating publisher", err)
+		return
+	}
+
+	msg := rmq.NewMessage([]byte("timeout-demo-message"))
+	result, err := publisher.Publish(context.Background(), msg)
+	if err != nil {
+		rmq.Error("Error publishing message", err)
+		return
+	}
+	switch result.Outcome.(type) {
+	case *rmq.StateAccepted:
+		rmq.Info("[Publisher] Message accepted by broker")
+	case *rmq.StateReleased:
+		rmq.Warn("[Publisher] Message released (not routed)")
+		return
+	case *rmq.StateRejected:
+		rmq.Error("[Publisher] Message rejected", "outcome", result.Outcome)
+		return
+	}
+	_ = publisher.Close(context.Background())
+
+	// Track whether the OnDeliveryRelease callback fired and the second delivery succeeded.
+	var releaseCallbackFired atomic.Bool
+	var finalAccept atomic.Bool
+
+	released := make(chan struct{}, 1)
+	accepted := make(chan struct{}, 1)
+
+	// 3. Create a consumer with:
+	//    - ConsumerTimeout: per-consumer override (takes precedence over queue-level setting)
+	//    - OnDeliveryRelease: called when the broker releases the timed-out delivery
+	consumer, err := conn.NewConsumer(context.Background(), queueName, &rmq.ConsumerOptions{
+		// Override timeout at the per-consumer level (here same as queue-level for clarity).
+		ConsumerTimeout: consumerTimeout,
+
+		// OnDeliveryRelease is invoked when the broker releases the delivery after timeout.
+		// Only Accept() is valid here – calling Discard or Requeue returns an error.
+		OnDeliveryRelease: func(deliveryCtx rmq.IDeliveryContext, message *amqp.Message) {
+			rmq.Info("[Consumer] Delivery released by broker (consumer timeout fired)",
+				"body", string(message.GetData()))
+
+			releaseCallbackFired.Store(true)
+
+			// Accept the message to unlock the consumer from the timeout state.
+			if acceptErr := deliveryCtx.Accept(context.Background()); acceptErr != nil {
+				rmq.Error("[Consumer] Failed to accept timed-out delivery", "error", acceptErr)
+			} else {
+				rmq.Info("[Consumer] Accepted timed-out delivery – consumer unlocked")
+			}
+			released <- struct{}{}
+		},
+	})
+	if err != nil {
+		rmq.Error("Error creating consumer", err)
+		return
+	}
+
+	rmq.Info("[Consumer] Attached with consumer timeout", "timeout", consumerTimeout)
+
+	consumerCtx, cancel := context.WithCancel(context.Background())
+	go func(ctx context.Context) {
+		for {
+			deliveryCtx, recvErr := consumer.Receive(ctx)
+			if errors.Is(recvErr, context.Canceled) {
+				rmq.Info("[Consumer] Consumer context cancelled, exiting receive loop")
+				return
+			}
+			if recvErr != nil {
+				rmq.Error("[Consumer] Error receiving message", "error", recvErr)
+				return
+			}
+
+			msg := deliveryCtx.Message()
+			rmq.Info("[Consumer] Message received – waiting past timeout to trigger OnDeliveryRelease",
+				"body", string(msg.GetData()))
+
+			// Deliberately hold the message for longer than the consumer timeout so the broker
+			// fires the consumer-timeout mechanism and triggers OnDeliveryRelease above.
+			// After OnDeliveryRelease calls Accept(), the consumer is unlocked and the requeued
+			// message is redelivered – we accept it here on the second delivery.
+			time.Sleep(consumerTimeout + 3*time.Second)
+
+			acceptErr := deliveryCtx.Accept(ctx)
+			if acceptErr != nil {
+				// Expected on the first delivery: the broker has already released it.
+				rmq.Warn("[Consumer] Accept on first delivery failed (expected after timeout)",
+					"error", acceptErr)
+			} else {
+				// Second delivery (after unlock): Accept succeeds.
+				rmq.Info("[Consumer] Message accepted on second delivery",
+					"body", string(msg.GetData()))
+				finalAccept.Store(true)
+				accepted <- struct{}{}
+			}
+		}
+	}(consumerCtx)
+
+	// Wait for the release callback to fire (broker releases due to timeout).
+	select {
+	case <-released:
+		rmq.Info("OnDeliveryRelease callback fired successfully")
+	case <-time.After(30 * time.Second):
+		rmq.Error("Timed out waiting for OnDeliveryRelease callback")
+	}
+
+	// Wait for the redelivered message to be accepted.
+	select {
+	case <-accepted:
+		rmq.Info("Redelivered message accepted successfully")
+	case <-time.After(30 * time.Second):
+		rmq.Error("Timed out waiting for redelivered message acceptance")
+	}
+
+	cancel()
+	_ = consumer.Close(context.Background())
+
+	_ = management.DeleteQueue(context.Background(), queueName)
+	rmq.Info("Example completed", "release_callback_fired", releaseCallbackFired.Load(), "final_accept", finalAccept.Load())
+}

--- a/pkg/rabbitmqamqp/amqp_consumer.go
+++ b/pkg/rabbitmqamqp/amqp_consumer.go
@@ -137,6 +137,10 @@ func (dc *DeliveryContext) RequeueWithAnnotations(ctx context.Context, annotatio
 // the broker has already settled the delivery, so the application cannot accept/reject/release it.
 var ErrPreSettledMessageDisposed = errors.New("auto-settle on, message is already disposed")
 
+// ErrDeliveryReleaseInvalidOperation is returned when Discard, Requeue, or Batch is called on
+// a TimedOutDeliveryContext. Only Accept() is valid for a broker-released timed-out delivery.
+var ErrDeliveryReleaseInvalidOperation = errors.New("only Accept is valid for a timed-out delivery context")
+
 // PreSettledDeliveryContext represents a delivery context for pre-settled messages.
 // All settlement methods throw errors since the message is already settled.
 type PreSettledDeliveryContext struct {
@@ -165,6 +169,45 @@ func (dc *PreSettledDeliveryContext) Requeue(ctx context.Context) error {
 
 func (dc *PreSettledDeliveryContext) RequeueWithAnnotations(ctx context.Context, annotations amqp.Annotations) error {
 	return ErrPreSettledMessageDisposed
+}
+
+// TimedOutDeliveryContext is the IDeliveryContext provided to DeliveryReleaseFunc when the broker
+// releases a delivery because the consumer did not settle it within the configured consumer timeout.
+// Only Accept() is valid; all other settlement methods return ErrDeliveryReleaseInvalidOperation.
+// Calling Accept() sends an AMQP Accepted disposition back to the broker, unlocking the consumer.
+type TimedOutDeliveryContext struct {
+	receiver         *amqp.Receiver
+	message          *amqp.Message
+	metricsCollector MetricsCollector
+	consumeCtx       ConsumeContext
+}
+
+func (t *TimedOutDeliveryContext) Message() *amqp.Message {
+	return t.message
+}
+
+func (t *TimedOutDeliveryContext) Accept(ctx context.Context) error {
+	err := t.receiver.AcceptMessage(ctx, t.message)
+	if err == nil {
+		t.metricsCollector.ConsumeDisposition(ConsumeUnlocked, t.consumeCtx)
+	}
+	return err
+}
+
+func (t *TimedOutDeliveryContext) Discard(_ context.Context, _ *amqp.Error) error {
+	return ErrDeliveryReleaseInvalidOperation
+}
+
+func (t *TimedOutDeliveryContext) DiscardWithAnnotations(_ context.Context, _ amqp.Annotations) error {
+	return ErrDeliveryReleaseInvalidOperation
+}
+
+func (t *TimedOutDeliveryContext) Requeue(_ context.Context) error {
+	return ErrDeliveryReleaseInvalidOperation
+}
+
+func (t *TimedOutDeliveryContext) RequeueWithAnnotations(_ context.Context, _ amqp.Annotations) error {
+	return ErrDeliveryReleaseInvalidOperation
 }
 
 type consumerState byte
@@ -328,6 +371,8 @@ func (c *Consumer) createReceiver(ctx context.Context) error {
 		// so, by default we use AtLeastOnce settlement mode even is not specified
 		receiverOptions = createReceiverLinkOptions(c.destinationAdd, c.options, AtLeastOnce)
 		setSingleActiveConsumerLinkStateHandler(receiverOptions, c.options, c)
+		setConsumerTimeoutProperty(receiverOptions, c.options)
+		setDeliveryReleaseHandler(receiverOptions, c.options, c)
 	}
 
 	receiver, err := c.connection.session.NewReceiver(ctx, c.destinationAdd, receiverOptions)

--- a/pkg/rabbitmqamqp/amqp_types.go
+++ b/pkg/rabbitmqamqp/amqp_types.go
@@ -147,6 +147,16 @@ type ConsumerOptions struct {
 	// updates for rabbitmq:active on this consumer link. Use with a quorum queue
 	// declared using SingleActiveConsumer. See SingleActiveConsumerStateChangedFunc.
 	SingleActiveConsumerStateChanged SingleActiveConsumerStateChangedFunc
+
+	// ConsumerTimeout sets the rabbitmq:consumer-timeout AMQP 1.0 ATTACH link property
+	// (expressed as milliseconds). Use with quorum or JMS queues to override the queue-level
+	// x-consumer-timeout on a per-consumer basis. Requires RabbitMQ 4.3 or later.
+	// Cannot be used with DirectReplyTo settle strategy.
+	ConsumerTimeout time.Duration
+
+	// OnDeliveryRelease is called when the broker releases a delivery due to consumer timeout.
+	// See DeliveryReleaseFunc for details. Requires RabbitMQ 4.3 or later.
+	OnDeliveryRelease DeliveryReleaseFunc
 }
 
 func (aco *ConsumerOptions) linkName() string {
@@ -178,6 +188,14 @@ func (aco *ConsumerOptions) validate(available *featuresAvailable) error {
 		if !available.is43rMore {
 			return fmt.Errorf("single active consumer state notification requires RabbitMQ 4.3 or later")
 		}
+	}
+
+	if aco.ConsumerTimeout > 0 && aco.SettleStrategy == DirectReplyTo {
+		return fmt.Errorf("consumer timeout is not supported with DirectReplyTo settle strategy")
+	}
+
+	if aco.OnDeliveryRelease != nil && !available.is43rMore {
+		return fmt.Errorf("OnDeliveryRelease callback requires RabbitMQ 4.3 or later")
 	}
 
 	return nil
@@ -217,6 +235,19 @@ const rabbitmqActiveLinkStateProperty = "rabbitmq:active"
 // Requires RabbitMQ 4.3+, a quorum queue declared with x-single-active-consumer,
 // and cannot be used together with DirectReplyTo.
 type SingleActiveConsumerStateChangedFunc func(consumer *Consumer, isActive bool)
+
+// DeliveryReleaseFunc is called when the broker releases a delivery because the consumer
+// did not settle it within the configured consumer timeout (x-consumer-timeout on the queue
+// or rabbitmq:consumer-timeout on the AMQP attach frame).
+//
+// The provided deliveryCtx is a restricted IDeliveryContext: only Accept() is valid.
+// Calling Discard, Requeue, or any other method returns ErrDeliveryReleaseInvalidOperation.
+//
+// Calling Accept() inside this callback sends an AMQP Accepted disposition back to the
+// broker, which unlocks the consumer so it can receive further messages.
+//
+// Requires RabbitMQ 4.3 or later.
+type DeliveryReleaseFunc func(deliveryCtx IDeliveryContext, message *amqp.Message)
 
 const offsetFirst = "first"
 const offsetNext = "next"

--- a/pkg/rabbitmqamqp/amqp_utils.go
+++ b/pkg/rabbitmqamqp/amqp_utils.go
@@ -96,6 +96,61 @@ func createDynamicReceiverLinkOptions(options IConsumerOptions) *amqp.ReceiverOp
 	}
 }
 
+// setConsumerTimeoutProperty injects the rabbitmq:consumer-timeout attach property (milliseconds)
+// when ConsumerOptions.ConsumerTimeout is set. This is only supported on quorum and JMS queues
+// and requires RabbitMQ 4.3 or later.
+func setConsumerTimeoutProperty(opts *amqp.ReceiverOptions, options IConsumerOptions) {
+	if opts == nil || options == nil {
+		return
+	}
+	co, ok := options.(*ConsumerOptions)
+	if !ok || co.ConsumerTimeout <= 0 {
+		return
+	}
+	if opts.Properties == nil {
+		opts.Properties = make(map[string]any)
+	}
+	opts.Properties[rabbitmqConsumerTimeoutProperty] = uint64(co.ConsumerTimeout.Milliseconds())
+}
+
+// setDeliveryReleaseHandler wires up ReceiverOptions.OnDeliveryStateChanged when
+// ConsumerOptions.OnDeliveryRelease is set. The callback is dispatched to a new
+// goroutine so the caller can safely call blocking operations such as Accept().
+func setDeliveryReleaseHandler(opts *amqp.ReceiverOptions, options IConsumerOptions, c *Consumer) {
+	if opts == nil || c == nil || options == nil {
+		return
+	}
+	co, ok := options.(*ConsumerOptions)
+	if !ok || co.OnDeliveryRelease == nil {
+		return
+	}
+	handler := co.OnDeliveryRelease
+	opts.OnDeliveryStateChanged = func(msg *amqp.Message, state amqp.DeliveryState) {
+		if _, released := state.(*amqp.StateReleased); !released {
+			return
+		}
+		receiver := c.receiver.Load()
+		if receiver == nil {
+			return
+		}
+		consumeCtx := c.buildConsumeContext(msg)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					Error("OnDeliveryRelease handler panicked", "recover", r)
+				}
+			}()
+			timedOutCtx := &TimedOutDeliveryContext{
+				receiver:         receiver,
+				message:          msg,
+				metricsCollector: c.connection.metricsCollector,
+				consumeCtx:       consumeCtx,
+			}
+			handler(timedOutCtx, msg)
+		}()
+	}
+}
+
 func random(max int) int {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	return r.Intn(max)

--- a/pkg/rabbitmqamqp/common.go
+++ b/pkg/rabbitmqamqp/common.go
@@ -34,6 +34,11 @@ const (
 	queues                = "queues"
 	bindings              = "bindings"
 	authTokens            = "/auth/tokens"
+
+	// rabbitmqConsumerTimeoutProperty is the AMQP 1.0 ATTACH link property key used to set
+	// a per-consumer message-lock timeout (milliseconds) for quorum and JMS queues.
+	// Requires RabbitMQ 4.3 or later.
+	rabbitmqConsumerTimeoutProperty = "rabbitmq:consumer-timeout"
 )
 
 func validatePositive(label string, value int64) error {

--- a/pkg/rabbitmqamqp/consumer_timeout_test.go
+++ b/pkg/rabbitmqamqp/consumer_timeout_test.go
@@ -1,0 +1,384 @@
+package rabbitmqamqp
+
+import (
+	"context"
+	"time"
+
+	"github.com/Azure/go-amqp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// ─── unit tests ──────────────────────────────────────────────────────────────
+// These describe blocks do NOT connect to a broker.
+
+var _ = Describe("QuorumQueueSpecification consumer timeout", func() {
+	It("sets x-consumer-timeout in milliseconds when ConsumerTimeout is set", func() {
+		spec := &QuorumQueueSpecification{
+			Name:            "my-qq",
+			ConsumerTimeout: 30 * time.Second,
+		}
+		args := spec.buildArguments()
+		Expect(args["x-consumer-timeout"]).To(Equal(int64(30_000)))
+		Expect(args["x-queue-type"]).To(Equal("quorum"))
+	})
+
+	It("does not set x-consumer-timeout when ConsumerTimeout is zero", func() {
+		spec := &QuorumQueueSpecification{Name: "my-qq"}
+		args := spec.buildArguments()
+		Expect(args).ToNot(HaveKey("x-consumer-timeout"))
+	})
+
+	It("combines ConsumerTimeout with other quorum arguments", func() {
+		spec := &QuorumQueueSpecification{
+			Name:              "my-qq",
+			DeliveryLimit:     5,
+			TargetClusterSize: 3,
+			ConsumerTimeout:   90 * time.Second,
+		}
+		args := spec.buildArguments()
+		Expect(args["x-consumer-timeout"]).To(Equal(int64(90_000)))
+		Expect(args["x-max-delivery-limit"]).To(BeNil()) // field is named DeliveryLimit → x-delivery-limit
+		Expect(args["x-delivery-limit"]).To(Equal(int64(5)))
+		Expect(args["x-quorum-target-group-size"]).To(Equal(int64(3)))
+		Expect(args["x-queue-type"]).To(Equal("quorum"))
+	})
+
+	It("fails validate when ConsumerTimeout is set on RabbitMQ < 4.3", func() {
+		spec := &QuorumQueueSpecification{
+			Name:            "my-qq",
+			ConsumerTimeout: 5 * time.Second,
+		}
+		err := spec.validate(&featuresAvailable{is43rMore: false})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("4.3"))
+	})
+
+	It("passes validate when ConsumerTimeout is set on RabbitMQ >= 4.3", func() {
+		spec := &QuorumQueueSpecification{
+			Name:            "my-qq",
+			ConsumerTimeout: 5 * time.Second,
+		}
+		Expect(spec.validate(&featuresAvailable{is43rMore: true})).To(BeNil())
+	})
+
+	It("passes validate when ConsumerTimeout is zero regardless of version", func() {
+		spec := &QuorumQueueSpecification{Name: "my-qq"}
+		Expect(spec.validate(&featuresAvailable{is43rMore: false})).To(BeNil())
+		Expect(spec.validate(&featuresAvailable{is43rMore: true})).To(BeNil())
+		Expect(spec.validate(nil)).To(BeNil())
+	})
+})
+
+var _ = Describe("JMSQueueSpecification consumer timeout", func() {
+	It("sets x-consumer-timeout in milliseconds when ConsumerTimeout is set", func() {
+		spec := &JMSQueueSpecification{
+			Name:            "my-jms",
+			ConsumerTimeout: 2 * time.Minute,
+		}
+		args := spec.buildArguments()
+		Expect(args["x-consumer-timeout"]).To(Equal(int64(120_000)))
+		Expect(args["x-queue-type"]).To(Equal("jms"))
+	})
+
+	It("does not set x-consumer-timeout when ConsumerTimeout is zero", func() {
+		spec := &JMSQueueSpecification{Name: "my-jms"}
+		args := spec.buildArguments()
+		Expect(args).ToNot(HaveKey("x-consumer-timeout"))
+	})
+})
+
+var _ = Describe("ConsumerOptions consumer timeout validation", func() {
+	It("rejects ConsumerTimeout with DirectReplyTo settle strategy", func() {
+		opts := &ConsumerOptions{
+			SettleStrategy:  DirectReplyTo,
+			ConsumerTimeout: 10 * time.Second,
+		}
+		// Provide a 4.3+ featureSet so only the consumer-timeout rule fires.
+		err := opts.validate(&featuresAvailable{is42rMore: true, is43rMore: true})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("DirectReplyTo"))
+	})
+
+	It("rejects OnDeliveryRelease on RabbitMQ < 4.3", func() {
+		opts := &ConsumerOptions{
+			OnDeliveryRelease: func(_ IDeliveryContext, _ *amqp.Message) {},
+		}
+		err := opts.validate(&featuresAvailable{is43rMore: false})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("4.3"))
+	})
+
+	It("accepts OnDeliveryRelease on RabbitMQ >= 4.3", func() {
+		opts := &ConsumerOptions{
+			OnDeliveryRelease: func(_ IDeliveryContext, _ *amqp.Message) {},
+		}
+		Expect(opts.validate(&featuresAvailable{is43rMore: true})).To(BeNil())
+	})
+
+	It("accepts ConsumerTimeout with ExplicitSettle on RabbitMQ >= 4.3", func() {
+		opts := &ConsumerOptions{
+			SettleStrategy:  ExplicitSettle,
+			ConsumerTimeout: 30 * time.Second,
+		}
+		Expect(opts.validate(&featuresAvailable{is43rMore: true})).To(BeNil())
+	})
+})
+
+var _ = Describe("TimedOutDeliveryContext", func() {
+	// Build a minimal TimedOutDeliveryContext without a real receiver/message;
+	// the restricted methods check the error before touching those fields.
+	var ctx *TimedOutDeliveryContext
+
+	BeforeEach(func() {
+		ctx = &TimedOutDeliveryContext{
+			receiver:         nil,
+			message:          nil,
+			metricsCollector: DefaultMetricsCollector(),
+		}
+	})
+
+	It("Discard returns ErrDeliveryReleaseInvalidOperation", func() {
+		err := ctx.Discard(context.Background(), nil)
+		Expect(err).To(MatchError(ErrDeliveryReleaseInvalidOperation))
+	})
+
+	It("DiscardWithAnnotations returns ErrDeliveryReleaseInvalidOperation", func() {
+		err := ctx.DiscardWithAnnotations(context.Background(), amqp.Annotations{"x-reason": "test"})
+		Expect(err).To(MatchError(ErrDeliveryReleaseInvalidOperation))
+	})
+
+	It("Requeue returns ErrDeliveryReleaseInvalidOperation", func() {
+		err := ctx.Requeue(context.Background())
+		Expect(err).To(MatchError(ErrDeliveryReleaseInvalidOperation))
+	})
+
+	It("RequeueWithAnnotations returns ErrDeliveryReleaseInvalidOperation", func() {
+		err := ctx.RequeueWithAnnotations(context.Background(), amqp.Annotations{"x-reason": "retry"})
+		Expect(err).To(MatchError(ErrDeliveryReleaseInvalidOperation))
+	})
+
+	It("Message returns the stored message", func() {
+		msg := &amqp.Message{}
+		ctx.message = msg
+		Expect(ctx.Message()).To(BeIdenticalTo(msg))
+	})
+})
+
+var _ = Describe("setConsumerTimeoutProperty", func() {
+	It("sets rabbitmq:consumer-timeout in the receiver properties", func() {
+		opts := &amqp.ReceiverOptions{}
+		consumerOpts := &ConsumerOptions{ConsumerTimeout: 45 * time.Second}
+		setConsumerTimeoutProperty(opts, consumerOpts)
+		Expect(opts.Properties).To(HaveKey(rabbitmqConsumerTimeoutProperty))
+		Expect(opts.Properties[rabbitmqConsumerTimeoutProperty]).To(Equal(uint64(45_000)))
+	})
+
+	It("does not set the property when ConsumerTimeout is zero", func() {
+		opts := &amqp.ReceiverOptions{}
+		setConsumerTimeoutProperty(opts, &ConsumerOptions{})
+		Expect(opts.Properties).To(BeNil())
+	})
+
+	It("does not set the property for non-ConsumerOptions types", func() {
+		opts := &amqp.ReceiverOptions{}
+		setConsumerTimeoutProperty(opts, &StreamConsumerOptions{})
+		Expect(opts.Properties).To(BeNil())
+	})
+
+	It("preserves existing properties when adding consumer timeout", func() {
+		opts := &amqp.ReceiverOptions{
+			Properties: map[string]any{"paired": true},
+		}
+		consumerOpts := &ConsumerOptions{ConsumerTimeout: 10 * time.Second}
+		setConsumerTimeoutProperty(opts, consumerOpts)
+		Expect(opts.Properties).To(HaveKey("paired"))
+		Expect(opts.Properties[rabbitmqConsumerTimeoutProperty]).To(Equal(uint64(10_000)))
+	})
+})
+
+var _ = Describe("setDeliveryReleaseHandler", func() {
+	It("does not set OnDeliveryStateChanged when OnDeliveryRelease is nil", func() {
+		opts := &amqp.ReceiverOptions{}
+		setDeliveryReleaseHandler(opts, &ConsumerOptions{}, &Consumer{})
+		Expect(opts.OnDeliveryStateChanged).To(BeNil())
+	})
+
+	It("sets OnDeliveryStateChanged when OnDeliveryRelease is configured", func() {
+		opts := &amqp.ReceiverOptions{}
+		called := false
+		consumerOpts := &ConsumerOptions{
+			OnDeliveryRelease: func(_ IDeliveryContext, _ *amqp.Message) {
+				called = true
+			},
+		}
+		setDeliveryReleaseHandler(opts, consumerOpts, &Consumer{
+			connection: &AmqpConnection{metricsCollector: DefaultMetricsCollector()},
+		})
+		Expect(opts.OnDeliveryStateChanged).ToNot(BeNil())
+		_ = called // used in integration test
+	})
+
+	It("does not set OnDeliveryStateChanged for StreamConsumerOptions", func() {
+		opts := &amqp.ReceiverOptions{}
+		setDeliveryReleaseHandler(opts, &StreamConsumerOptions{}, &Consumer{})
+		Expect(opts.OnDeliveryStateChanged).To(BeNil())
+	})
+})
+
+// ─── integration tests ───────────────────────────────────────────────────────
+// These require a running RabbitMQ 4.3+ broker.
+
+var _ = Describe("Consumer timeout integration", func() {
+	It("creates a consumer with per-consumer ConsumerTimeout attach property", func() {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = connection.Close(context.Background()) })
+
+		qName := generateNameWithDateTime("consumer_timeout_attach")
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() {
+			_ = connection.Management().DeleteQueue(context.Background(), qName)
+		})
+
+		consumer, err := connection.NewConsumer(context.Background(), qName, &ConsumerOptions{
+			ConsumerTimeout: 30 * time.Second,
+		})
+		Expect(err).To(BeNil())
+		Expect(consumer).ToNot(BeNil())
+		Expect(consumer.Close(context.Background())).To(BeNil())
+	})
+
+	It("rejects ConsumerTimeout combined with DirectReplyTo", func() {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = connection.Close(context.Background()) })
+
+		qName := generateNameWithDateTime("consumer_timeout_direct_reply")
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() {
+			_ = connection.Management().DeleteQueue(context.Background(), qName)
+		})
+
+		_, err = connection.NewConsumer(context.Background(), qName, &ConsumerOptions{
+			SettleStrategy:  DirectReplyTo,
+			ConsumerTimeout: 10 * time.Second,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("DirectReplyTo"))
+	})
+
+	It("rejects OnDeliveryRelease on RabbitMQ < 4.3 (skipped when >= 4.3)", func() {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = connection.Close(context.Background()) })
+
+		ver, _ := connection.Properties()["version"].(string)
+		if isVersionGreaterOrEqual(extractVersion(ver), "4.3.0") {
+			Skip("broker is 4.3+, OnDeliveryRelease is supported — skip the rejection test")
+		}
+
+		qName := generateNameWithDateTime("consumer_timeout_too_old")
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name: qName,
+		})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() {
+			_ = connection.Management().DeleteQueue(context.Background(), qName)
+		})
+
+		_, err = connection.NewConsumer(context.Background(), qName, &ConsumerOptions{
+			OnDeliveryRelease: func(_ IDeliveryContext, _ *amqp.Message) {},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("4.3"))
+	})
+
+	It("declares a quorum queue with x-consumer-timeout and reads it back", func() {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = connection.Close(context.Background()) })
+
+		ver, _ := connection.Properties()["version"].(string)
+		if !isVersionGreaterOrEqual(extractVersion(ver), "4.3.0") {
+			Skip("requires RabbitMQ 4.3+ for x-consumer-timeout")
+		}
+
+		qName := generateNameWithDateTime("qq_consumer_timeout_arg")
+		info, err := connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name:            qName,
+			ConsumerTimeout: 15 * time.Minute,
+		})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() {
+			_ = connection.Management().DeleteQueue(context.Background(), qName)
+		})
+
+		Expect(info.Arguments()["x-consumer-timeout"]).To(Equal(int64(900_000)))
+	})
+
+	It("fires OnDeliveryRelease when broker releases due to queue-level consumer timeout", func(ctx SpecContext) {
+		connection, err := Dial(context.Background(), "amqp://", nil)
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = connection.Close(context.Background()) })
+
+		ver, _ := connection.Properties()["version"].(string)
+		if !isVersionGreaterOrEqual(extractVersion(ver), "4.3.0") {
+			Skip("requires RabbitMQ 4.3+ for consumer timeout feature")
+		}
+
+		// Use a queue-level ConsumerTimeout – this is the established way to trigger
+		// broker-initiated releases. The per-consumer attach property may additionally
+		// lower the effective timeout, but the queue-level setting drives the release.
+		queueTimeout := 5 * time.Second
+		qName := generateNameWithDateTime("qq_consumer_timeout_release")
+		_, err = connection.Management().DeclareQueue(context.Background(), &QuorumQueueSpecification{
+			Name:            qName,
+			ConsumerTimeout: queueTimeout,
+		})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() {
+			_ = connection.Management().DeleteQueue(context.Background(), qName)
+		})
+
+		releaseCh := make(chan struct{}, 1)
+		releaseCallbackFired := false
+
+		consumer, err := connection.NewConsumer(context.Background(), qName, &ConsumerOptions{
+			OnDeliveryRelease: func(deliveryCtx IDeliveryContext, _ *amqp.Message) {
+				releaseCallbackFired = true
+				// Accept() unlocks the consumer after the broker-initiated release.
+				_ = deliveryCtx.Accept(context.Background())
+				releaseCh <- struct{}{}
+			},
+		})
+		Expect(err).To(BeNil())
+		DeferCleanup(func() { _ = consumer.Close(context.Background()) })
+
+		// Publish one message.
+		publishMessages(qName, 1, "timeout-test-msg")
+
+		// Receive the message but never settle it so the queue-level timeout fires.
+		heldDeliveryCh := make(chan IDeliveryContext, 1)
+		go func() {
+			dc, recvErr := consumer.Receive(ctx)
+			if recvErr != nil {
+				return
+			}
+			heldDeliveryCh <- dc // hand it off so the goroutine stays alive, holding the delivery
+		}()
+
+		// Wait for the delivery to be held.
+		Eventually(heldDeliveryCh, 10*time.Second, 100*time.Millisecond).Should(Receive())
+
+		// The broker releases after queueTimeout – wait up to 3× that for the callback.
+		Eventually(releaseCh, queueTimeout*3, 100*time.Millisecond).Should(Receive())
+		Expect(releaseCallbackFired).To(BeTrue())
+	}, SpecTimeout(90*time.Second))
+})

--- a/pkg/rabbitmqamqp/entities.go
+++ b/pkg/rabbitmqamqp/entities.go
@@ -213,6 +213,10 @@ type QuorumQueueSpecification struct {
 	// DelayedRetryMax is the maximum delay before a message is redelivered.
 	// Requires RabbitMQ 4.3 or later. Maps to the x-delayed-retry-max queue argument (milliseconds).
 	DelayedRetryMax time.Duration
+	// ConsumerTimeout sets the x-consumer-timeout queue argument (milliseconds).
+	// This limits how long a consumer may hold a message without settling it.
+	// Requires RabbitMQ 4.3 or later.
+	ConsumerTimeout time.Duration
 	Arguments       map[string]any
 }
 
@@ -298,6 +302,10 @@ func (q *QuorumQueueSpecification) buildArguments() map[string]any {
 		result["x-delayed-retry-max"] = q.DelayedRetryMax.Milliseconds()
 	}
 
+	if q.ConsumerTimeout != 0 {
+		result["x-consumer-timeout"] = q.ConsumerTimeout.Milliseconds()
+	}
+
 	result["x-queue-type"] = string(q.queueType())
 	return result
 }
@@ -306,6 +314,11 @@ func (q *QuorumQueueSpecification) validate(f *featuresAvailable) error {
 	if f != nil && (len(q.DelayedRetryType) != 0 || q.DelayedRetryMin != 0 || q.DelayedRetryMax != 0) {
 		if !f.is43rMore {
 			return fmt.Errorf("QuorumQueueSpecification delayed retry fields require RabbitMQ 4.3 or later")
+		}
+	}
+	if f != nil && q.ConsumerTimeout != 0 {
+		if !f.is43rMore {
+			return fmt.Errorf("QuorumQueueSpecification consumer timeout requires RabbitMQ 4.3 or later")
 		}
 	}
 	return nil
@@ -536,6 +549,9 @@ type JMSQueueSpecification struct {
 	LeaderLocator        ILeaderLocator
 	InitialClusterSize   int
 	SelectorFields       []string
+	// ConsumerTimeout sets the x-consumer-timeout queue argument (milliseconds).
+	// This limits how long a consumer may hold a message without settling it.
+	ConsumerTimeout time.Duration
 }
 
 func (j *JMSQueueSpecification) name() string {
@@ -582,6 +598,10 @@ func (j *JMSQueueSpecification) buildArguments() map[string]any {
 
 	if j.OverflowStrategy != nil {
 		result["x-overflow"] = j.OverflowStrategy.overflowStrategy()
+	}
+
+	if j.ConsumerTimeout != 0 {
+		result["x-consumer-timeout"] = j.ConsumerTimeout.Milliseconds()
 	}
 
 	result["x-queue-type"] = string(j.queueType())

--- a/pkg/rabbitmqamqp/metrics.go
+++ b/pkg/rabbitmqamqp/metrics.go
@@ -22,6 +22,9 @@ const (
 	ConsumeDiscarded
 	// ConsumeRequeued indicates the consumer requeued the message for redelivery.
 	ConsumeRequeued
+	// ConsumeUnlocked indicates the consumer accepted a broker-released delivery to unlock
+	// itself from the consumer-timeout state (quorum/JMS queues, RabbitMQ 4.3+).
+	ConsumeUnlocked
 )
 
 // PublishContext contains contextual information for publish metrics,

--- a/pkg/rabbitmqamqp/metrics_otel.go
+++ b/pkg/rabbitmqamqp/metrics_otel.go
@@ -30,6 +30,7 @@ type OTELMetricsCollector struct {
 	consumedAccepted  metric.Int64Counter
 	consumedDiscarded metric.Int64Counter
 	consumedRequeued  metric.Int64Counter
+	consumedUnlocked  metric.Int64Counter
 }
 
 // Ensure OTELMetricsCollector implements MetricsCollector
@@ -144,6 +145,15 @@ func NewOTELMetricsCollector(meterProvider metric.MeterProvider, prefix string) 
 	collector.consumedRequeued, err = meter.Int64Counter(
 		prefix+".consumed_requeued",
 		metric.WithDescription("Total number of messages requeued by consumer"),
+		metric.WithUnit("{message}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	collector.consumedUnlocked, err = meter.Int64Counter(
+		prefix+".consumed_unlocked",
+		metric.WithDescription("Total number of broker-released deliveries accepted to unlock the consumer (consumer timeout)"),
 		metric.WithUnit("{message}"),
 	)
 	if err != nil {
@@ -276,5 +286,8 @@ func (o *OTELMetricsCollector) ConsumeDisposition(disposition ConsumeDisposition
 	case ConsumeRequeued:
 		attrs = append(attrs, MessagingOperationNameKey.String(OperationNameRequeue))
 		o.consumedRequeued.Add(context.Background(), 1, metric.WithAttributes(attrs...))
+	case ConsumeUnlocked:
+		attrs = append(attrs, MessagingOperationNameKey.String(OperationNameAck))
+		o.consumedUnlocked.Add(context.Background(), 1, metric.WithAttributes(attrs...))
 	}
 }


### PR DESCRIPTION
(RabbitMQ 4.3+)

Add support for the x-consumer-timeout mechanism introduced in RabbitMQ 4.3, which limits how long a consumer may hold a message without settling it.

Queue-level timeout:
- QuorumQueueSpecification.ConsumerTimeout sets the x-consumer-timeout queue argument (milliseconds) for quorum queues.
- JMSQueueSpecification.ConsumerTimeout does the same for JMS queues.

Per-consumer timeout (AMQP attach property):
- ConsumerOptions.ConsumerTimeout injects the rabbitmq:consumer-timeout link property into the AMQP ATTACH frame, overriding the queue-level setting. Not compatible with DirectReplyTo settle strategy.

Delivery release callback:
- DeliveryReleaseFunc is a new callback type invoked when the broker releases a delivery because the consumer did not settle it within the timeout.
- ConsumerOptions.OnDeliveryRelease wires this callback via the go-amqp v1.7.0 ReceiverOptions.OnDeliveryStateChanged hook.
- TimedOutDeliveryContext is a restricted IDeliveryContext where only Accept() is valid; Discard and Requeue return ErrDeliveryReleaseInvalidOperation. Calling Accept() sends AMQP Accepted back to the broker, unlocking the consumer.

Metrics:
- ConsumeUnlocked disposition value added to track unlock operations.
- consumedUnlocked OTEL counter added to OTELMetricsCollector.

Also includes a docs/examples/qq_consumer_timeout example demonstrating the full timeout-and-unlock flow.