### PR TITLE
ci: add GitHub Actions workflow to publish docs to pkg.go.dev

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,55 @@
+name: Publish docs to pkg.go.dev
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            TAG=$(git describe --tags --abbrev=0 --match="v*" 2>/dev/null || true)
+            echo "value=${TAG}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Resolved version: $(grep value $GITHUB_OUTPUT | cut -d= -f2)"
+
+      - uses: actions/setup-go@v5
+        if: steps.version.outputs.value != ''
+        with:
+          go-version: stable
+
+      - name: Warm up module proxy
+        if: steps.version.outputs.value != ''
+        env:
+          MODULE: github.com/rabbitmq/rabbitmq-amqp-go-client
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          GOPROXY=https://proxy.golang.org GONOSUMCHECK='*' \
+            go list -m "${MODULE}@${VERSION}"
+
+      - name: Notify pkg.go.dev
+        if: steps.version.outputs.value != ''
+        env:
+          MODULE: github.com/rabbitmq/rabbitmq-amqp-go-client
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          STATUS=$(curl -sSL -o /dev/null -w "%{http_code}" \
+            "https://pkg.go.dev/fetch/${MODULE}@${VERSION}")
+          echo "pkg.go.dev fetch status for ${MODULE}@${VERSION}: ${STATUS}"
+          # 200 = already indexed, 302/303 = fetch triggered, anything else is unexpected
+          if [[ "$STATUS" != "200" && "$STATUS" != "302" && "$STATUS" != "303" ]]; then
+            echo "Unexpected HTTP status ${STATUS} — documentation may be queued for indexing"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ __MACOSX/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# local
+local/

--- a/pkg/rabbitmqamqp/amqp_connection.go
+++ b/pkg/rabbitmqamqp/amqp_connection.go
@@ -180,9 +180,35 @@ func (a *AmqpConnection) Properties() map[string]any {
 }
 
 // NewPublisher creates a new Publisher that sends messages to the provided destination.
-// The destination is a ITargetAddress that can be a Queue or an Exchange with a routing key.
-// options is an IPublisherOptions that can be used to configure the publisher.
-// See QueueAddress and ExchangeAddress for more information.
+//
+// The destination parameter is an [ITargetAddress] — either a [QueueAddress], an
+// [ExchangeAddress], or nil.
+//
+// When destination is non-nil, the Publisher has a fixed target and all messages are
+// sent to that address:
+//
+//	target := &rabbitmqamqp.ExchangeAddress{Exchange: "my-exchange", Key: "my-key"}
+//	publisher, err := conn.NewPublisher(ctx, target, nil)
+//
+// When destination is nil, an Anonymous Sender is created. The target address must be
+// set per-message via [NewMessageWithAddress] or [MessagePropertyToAddress], allowing
+// different messages to be routed to different targets:
+//
+//	anonymousPublisher, err := conn.NewPublisher(ctx, nil, nil)
+//
+//	msg1, err := rabbitmqamqp.NewMessageWithAddress([]byte("pizza"), &rabbitmqamqp.ExchangeAddress{Exchange: "my-exchange", Key: "test"})
+//	anonymousPublisher.Publish(ctx, msg1)
+//
+//	msg2, err := rabbitmqamqp.NewMessageWithAddress([]byte("pasta"), &rabbitmqamqp.ExchangeAddress{Exchange: "another-exchange", Key: "another-key"})
+//	anonymousPublisher.Publish(ctx, msg2)
+//
+// Note: when the publisher has a fixed target, the message's To property
+// (message.Properties.To) is ignored.
+// [NewMessageWithAddress] or [MessagePropertyToAddress] are just helper functions to set message.Properties.To
+//
+// The options parameter configures the publisher (link name, max in-flight messages,
+// publish timeout, etc.). Pass nil to use the defaults. See [PublisherOptions].
+
 func (a *AmqpConnection) NewPublisher(ctx context.Context, destination ITargetAddress, options IPublisherOptions) (*Publisher, error) {
 	destinationAdd := ""
 	err := error(nil)

--- a/pkg/rabbitmqamqp/messages_helper.go
+++ b/pkg/rabbitmqamqp/messages_helper.go
@@ -2,12 +2,15 @@ package rabbitmqamqp
 
 import (
 	"errors"
+
 	"github.com/Azure/go-amqp"
 )
 
 // MessagePropertyToAddress sets the To property of the message to the address of the target.
 // The target must be a QueueAddress or an ExchangeAddress.
-// Note: The field msgRef.Properties.To will be overwritten if it is already set.
+// Note: The field message.Properties.To will be overwritten if it is already set.
+// Note: message.Properties.To routes the traffic to the destination only if the [Publisher] is anonymous.
+// See [NewPublisher] for more details.
 func MessagePropertyToAddress(msgRef *amqp.Message, target ITargetAddress) error {
 	if target == nil {
 		return errors.New("target cannot be nil")
@@ -33,6 +36,8 @@ func NewMessage(body []byte) *amqp.Message {
 // NewMessageWithAddress creates a new AMQP 1.0  new message with the given payload and sets the To property to the address of the target.
 // The target must be a QueueAddress or an ExchangeAddress.
 // This function is a helper that combines NewMessage and MessagePropertyToAddress.
+// Note: message.Properties.To routes the traffic to the destination only if the [Publisher] is anonymous.
+// See [NewPublisher] for more details.
 func NewMessageWithAddress(body []byte, target ITargetAddress) (*amqp.Message, error) {
 	message := amqp.NewMessage(body)
 	err := MessagePropertyToAddress(message, target)


### PR DESCRIPTION
Adds .github/workflows/publish-docs.yml that triggers on every push to main and on v* tag pushes. It resolves the nearest version tag, warms up the Go module proxy (proxy.golang.org), and calls the pkg.go.dev /fetch endpoint to ensure documentation is indexed promptly after each release.

Add documentation for message.properties.To fiels=d