### PR TITLE
chore: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,8 +20,8 @@ jobs:
         - stable
         - oldstable
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         id: setup_go
         with:
           go-version: ${{ matrix.go }}
@@ -36,7 +36,7 @@ jobs:
         run: ${{ github.workspace}}/.ci/ubuntu/gha-log-check.sh
       - name: Maybe upload RabbitMQ logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rabbitmq-logs-integration-ubuntu
           path: ${{ github.workspace }}/.ci/ubuntu/log/

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,7 +11,7 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
           fi
           echo "Resolved version: $(grep value $GITHUB_OUTPUT | cut -d= -f2)"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         if: steps.version.outputs.value != ''
         with:
           go-version: stable


### PR DESCRIPTION
Bump actions/checkout v4 → v6, actions/setup-go v5 → v6, and actions/upload-artifact v4 → v7 across all CI workflows.