### PR TITLE
fix: guard against short annotation key panic

### DIFF
--- a/pkg/rabbitmqamqp/amqp_utils.go
+++ b/pkg/rabbitmqamqp/amqp_utils.go
@@ -116,7 +116,7 @@ func validateMessageAnnotations(annotations amqp.Annotations) error {
 }
 
 func validateMessageAnnotationKey(key string) error {
-	if key[:2] != "x-" {
+	if len(key) < 2 || key[:2] != "x-" {
 		return fmt.Errorf("message annotation key must start with 'x-': %s", key)
 	}
 	return nil

--- a/pkg/rabbitmqamqp/amqp_utils_test.go
+++ b/pkg/rabbitmqamqp/amqp_utils_test.go
@@ -5,6 +5,31 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("validateMessageAnnotationKey", func() {
+	It("returns an error for an empty key without panicking", func() {
+		err := validateMessageAnnotationKey("")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("x-"))
+	})
+
+	It("returns an error for a single-character key without panicking", func() {
+		err := validateMessageAnnotationKey("x")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("x-"))
+	})
+
+	It("returns an error for a key that does not start with x-", func() {
+		err := validateMessageAnnotationKey("invalid-key")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("x-"))
+	})
+
+	It("returns nil for a valid key starting with x-", func() {
+		err := validateMessageAnnotationKey("x-something")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
 var _ = Describe("Encode and decode address", func() {
 	It("To address from address", func() {
 		type ExpectedQueuesAndDestination struct {


### PR DESCRIPTION
 Fix: guard against short annotation key panic in validateMessageAnnotationKey

Add a len(key) < 2 guard before the key[:2] slice in validateMessageAnnotationKey to prevent a runtime index-out-of-bounds panic when an empty string or single-character key is passed via the public DiscardWithAnnotations / RequeueWithAnnotations API. 

[ai-assisted=yes]