### PR TITLE
fix: Check type assertions for AMQP connection properties.

### DIFF
--- a/pkg/rabbitmqamqp/features_available.go
+++ b/pkg/rabbitmqamqp/features_available.go
@@ -42,17 +42,31 @@ func (f *featuresAvailable) ParseProperties(properties map[string]any) error {
 		return fmt.Errorf("missing version property")
 	}
 
-	version := extractVersion(properties["version"].(string))
+	versionStr, ok := properties["version"].(string)
+	if !ok {
+		return fmt.Errorf("version property must be a string, got %T", properties["version"])
+	}
+
+	version := extractVersion(versionStr)
 	if version == "" {
-		return fmt.Errorf("invalid version format: %s", version)
+		return fmt.Errorf("invalid version format: %s", versionStr)
 	}
 
 	f.is4OrMore = isVersionGreaterOrEqual(version, "4.0.0")
 	f.is41OrMore = isVersionGreaterOrEqual(version, "4.1.0")
 	f.is42rMore = isVersionGreaterOrEqual(version, "4.2.0")
 	f.is43rMore = isVersionGreaterOrEqual(version, "4.3.0")
-	f.isRabbitMQ = strings.EqualFold(properties["product"].(string), "RabbitMQ")
-	f.isTanzu = isTanzu(properties["version"].(string))
+
+	productStr, ok := properties["product"].(string)
+	if !ok {
+		// Non-standard AMQP server: degrade gracefully instead of panicking.
+		f.isRabbitMQ = false
+		f.isTanzu = false
+		return nil
+	}
+
+	f.isRabbitMQ = strings.EqualFold(productStr, "RabbitMQ")
+	f.isTanzu = isTanzu(versionStr)
 	return nil
 }
 

--- a/pkg/rabbitmqamqp/features_available_test.go
+++ b/pkg/rabbitmqamqp/features_available_test.go
@@ -186,4 +186,52 @@ var _ = Describe("Available Features", func() {
 		Expect(result.Error()).To(ContainSubstring("queue unavailable"))
 	})
 
+	// Security: unchecked type assertions on server-supplied connection properties.
+	// A rogue or MITM broker can send non-string values for "version"/"product",
+	// which previously caused a runtime panic at dial time (Vuln 2, SECURITY_REPORT.md).
+
+	It("ParseProperties returns error when 'product' key is absent", func() {
+		fa := newFeaturesAvailable()
+		err := fa.ParseProperties(map[string]any{
+			"version": "4.0.0",
+			// "product" intentionally absent
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fa.isRabbitMQ).To(BeFalse())
+		Expect(fa.isTanzu).To(BeFalse())
+		Expect(fa.is4OrMore).To(BeTrue())
+	})
+
+	It("ParseProperties returns error when 'version' is not a string", func() {
+		fa := newFeaturesAvailable()
+		err := fa.ParseProperties(map[string]any{
+			"version": 400,
+			"product": "RabbitMQ",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("string"))
+	})
+
+	It("ParseProperties returns error when 'product' is not a string", func() {
+		fa := newFeaturesAvailable()
+		err := fa.ParseProperties(map[string]any{
+			"version": "4.0.0",
+			"product": 99,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fa.isRabbitMQ).To(BeFalse())
+		Expect(fa.is4OrMore).To(BeTrue())
+	})
+
+	It("ParseProperties succeeds and marks isRabbitMQ false for a non-standard server", func() {
+		fa := newFeaturesAvailable()
+		err := fa.ParseProperties(map[string]any{
+			"version": "4.1.0",
+			"product": "SomeOtherBroker",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fa.isRabbitMQ).To(BeFalse())
+		Expect(fa.is41OrMore).To(BeTrue())
+	})
+
 })


### PR DESCRIPTION
Previously, server-supplied AMQP connection properties for version and product were asserted to string with bare casts. An AMQP broker that omits product or sends either field as a non-string AMQP type caused a runtime panic at dial time, crashing the client process.

Client now degrades gracefully with descriptive errors.

[ai-assited=yes]