### PR TITLE
Support stream-initial-offset arguments for stream queues (#126)

### DIFF
--- a/pkg/rabbitmqamqp/entities.go
+++ b/pkg/rabbitmqamqp/entities.go
@@ -566,6 +566,8 @@ type StreamQueueSpecification struct {
 	SegmentSize int64
 	// FilterSizeBytes is the size in bytes of the Bloom filter used for stream filtering (x-stream-filter-size-bytes).
 	FilterSizeBytes int64
+	// InitialOffset is the offset from which the stream should start reading messages (x-stream-initial-offset).
+	InitialOffset int64
 	// Arguments holds additional queue arguments passed directly to the broker.
 	Arguments map[string]any
 }
@@ -612,12 +614,27 @@ func (s *StreamQueueSpecification) buildArguments() map[string]any {
 		result["x-stream-filter-size-bytes"] = s.FilterSizeBytes
 	}
 
+	if s.InitialOffset != 0 {
+		result["x-stream-initial-offset"] = s.InitialOffset
+	}
+
 	result["x-queue-type"] = string(s.queueType())
 
 	return result
 }
 
-func (s *StreamQueueSpecification) validate(*featuresAvailable) error {
+const MaxStreamInitialOffset = (1 << 62) - 1
+
+func (s *StreamQueueSpecification) validate(f *featuresAvailable) error {
+	if s.InitialOffset != 0 {
+		if s.InitialOffset < 0 || s.InitialOffset > MaxStreamInitialOffset {
+			return fmt.Errorf("initial offset must be between 0 and %d", MaxStreamInitialOffset)
+		}
+
+		if f != nil && !f.is44rMore {
+			return fmt.Errorf("stream initial offset is not supported. You need to use RabbitMQ 4.4 or later")
+		}
+	}
 	return nil
 }
 

--- a/pkg/rabbitmqamqp/entities_test.go
+++ b/pkg/rabbitmqamqp/entities_test.go
@@ -84,6 +84,60 @@ var _ = Describe("Entities", func() {
 			args := spec.buildArguments()
 			Expect(args["x-queue-type"]).To(Equal("stream"))
 		})
+
+		It("sets x-stream-initial-offset when InitialOffset is non-zero", func() {
+			spec := &StreamQueueSpecification{
+				Name:          "my-stream",
+				InitialOffset: 1000,
+			}
+			args := spec.buildArguments()
+			Expect(args["x-stream-initial-offset"]).To(Equal(int64(1000)))
+			Expect(args["x-queue-type"]).To(Equal("stream"))
+		})
+
+		It("does not set x-stream-initial-offset when InitialOffset is zero", func() {
+			spec := &StreamQueueSpecification{Name: "my-stream"}
+			args := spec.buildArguments()
+			Expect(args).ToNot(HaveKey("x-stream-initial-offset"))
+		})
+
+		It("fails validate when InitialOffset is set on RabbitMQ < 4.4", func() {
+			spec := &StreamQueueSpecification{
+				Name:          "my-stream",
+				InitialOffset: 500,
+			}
+			err := spec.validate(&featuresAvailable{is44rMore: false})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("4.4"))
+		})
+
+		It("passes validate when InitialOffset is set on RabbitMQ >= 4.4", func() {
+			spec := &StreamQueueSpecification{
+				Name:          "my-stream",
+				InitialOffset: 500,
+			}
+			Expect(spec.validate(&featuresAvailable{is44rMore: true})).To(BeNil())
+		})
+
+		It("fails validate when InitialOffset is negative", func() {
+			spec := &StreamQueueSpecification{
+				Name:          "my-stream",
+				InitialOffset: -1,
+			}
+			err := spec.validate(&featuresAvailable{is44rMore: true})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("between 0 and"))
+		})
+
+		It("fails validate when InitialOffset exceeds MaxStreamInitialOffset", func() {
+			spec := &StreamQueueSpecification{
+				Name:          "my-stream",
+				InitialOffset: MaxStreamInitialOffset + 1,
+			}
+			err := spec.validate(&featuresAvailable{is44rMore: true})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("between 0 and"))
+		})
 	})
 
 	Describe("JMSQueueSpecification", func() {

--- a/pkg/rabbitmqamqp/features_available.go
+++ b/pkg/rabbitmqamqp/features_available.go
@@ -29,6 +29,7 @@ type featuresAvailable struct {
 	is41OrMore bool
 	is42rMore  bool
 	is43rMore  bool
+	is44rMore  bool
 	isRabbitMQ bool
 	isTanzu    bool
 }
@@ -56,6 +57,7 @@ func (f *featuresAvailable) ParseProperties(properties map[string]any) error {
 	f.is41OrMore = isVersionGreaterOrEqual(version, "4.1.0")
 	f.is42rMore = isVersionGreaterOrEqual(version, "4.2.0")
 	f.is43rMore = isVersionGreaterOrEqual(version, "4.3.0")
+	f.is44rMore = isVersionGreaterOrEqual(version, "4.4.0")
 
 	productStr, ok := properties["product"].(string)
 	if !ok {

--- a/pkg/rabbitmqamqp/features_available_test.go
+++ b/pkg/rabbitmqamqp/features_available_test.go
@@ -65,6 +65,9 @@ var _ = Describe("Available Features", func() {
 		})).To(BeNil())
 		Expect(availableFeatures.is4OrMore).To(BeFalse())
 		Expect(availableFeatures.is41OrMore).To(BeFalse())
+		Expect(availableFeatures.is42rMore).To(BeFalse())
+		Expect(availableFeatures.is43rMore).To(BeFalse())
+		Expect(availableFeatures.is44rMore).To(BeFalse())
 		Expect(availableFeatures.isRabbitMQ).To(BeTrue())
 
 		Expect(availableFeatures.ParseProperties(map[string]any{
@@ -73,6 +76,9 @@ var _ = Describe("Available Features", func() {
 		})).To(BeNil())
 		Expect(availableFeatures.is4OrMore).To(BeFalse())
 		Expect(availableFeatures.is41OrMore).To(BeFalse())
+		Expect(availableFeatures.is42rMore).To(BeFalse())
+		Expect(availableFeatures.is43rMore).To(BeFalse())
+		Expect(availableFeatures.is44rMore).To(BeFalse())
 		Expect(availableFeatures.isRabbitMQ).To(BeTrue())
 
 		Expect(availableFeatures.ParseProperties(map[string]any{
@@ -82,6 +88,9 @@ var _ = Describe("Available Features", func() {
 
 		Expect(availableFeatures.is4OrMore).To(BeTrue())
 		Expect(availableFeatures.is41OrMore).To(BeFalse())
+		Expect(availableFeatures.is42rMore).To(BeFalse())
+		Expect(availableFeatures.is43rMore).To(BeFalse())
+		Expect(availableFeatures.is44rMore).To(BeFalse())
 		Expect(availableFeatures.isRabbitMQ).To(BeTrue())
 
 		Expect(availableFeatures.ParseProperties(map[string]any{
@@ -91,6 +100,9 @@ var _ = Describe("Available Features", func() {
 
 		Expect(availableFeatures.is4OrMore).To(BeTrue())
 		Expect(availableFeatures.is41OrMore).To(BeTrue())
+		Expect(availableFeatures.is42rMore).To(BeFalse())
+		Expect(availableFeatures.is43rMore).To(BeFalse())
+		Expect(availableFeatures.is44rMore).To(BeFalse())
 		Expect(availableFeatures.isRabbitMQ).To(BeTrue())
 
 		Expect(availableFeatures.ParseProperties(map[string]any{
@@ -100,6 +112,9 @@ var _ = Describe("Available Features", func() {
 
 		Expect(availableFeatures.is4OrMore).To(BeTrue())
 		Expect(availableFeatures.is41OrMore).To(BeTrue())
+		Expect(availableFeatures.is42rMore).To(BeFalse())
+		Expect(availableFeatures.is43rMore).To(BeFalse())
+		Expect(availableFeatures.is44rMore).To(BeFalse())
 		Expect(availableFeatures.isRabbitMQ).To(BeFalse())
 
 		Expect(availableFeatures.ParseProperties(map[string]any{
@@ -109,6 +124,21 @@ var _ = Describe("Available Features", func() {
 
 		Expect(availableFeatures.is4OrMore).To(BeTrue())
 		Expect(availableFeatures.is41OrMore).To(BeTrue())
+		Expect(availableFeatures.is42rMore).To(BeFalse())
+		Expect(availableFeatures.is43rMore).To(BeFalse())
+		Expect(availableFeatures.is44rMore).To(BeFalse())
+		Expect(availableFeatures.isRabbitMQ).To(BeTrue())
+
+		Expect(availableFeatures.ParseProperties(map[string]any{
+			"version": "4.4.0",
+			"product": "rabbitmq",
+		})).To(BeNil())
+
+		Expect(availableFeatures.is4OrMore).To(BeTrue())
+		Expect(availableFeatures.is41OrMore).To(BeTrue())
+		Expect(availableFeatures.is42rMore).To(BeTrue())
+		Expect(availableFeatures.is43rMore).To(BeTrue())
+		Expect(availableFeatures.is44rMore).To(BeTrue())
 		Expect(availableFeatures.isRabbitMQ).To(BeTrue())
 	})
 


### PR DESCRIPTION
Implements support for the stream-initial-offset argument when declaring stream queues, matching the feature implementation in the Java client (rabbitmq/rabbitmq-stream-java-client#1081).

**Changes**

-  Version Capability: Added is44rMore feature flag parsing to features_available.go targeting RabbitMQ 4.4+.

-  Stream Specification: Exposed InitialOffset in StreamQueueSpecification with bounds checking between 0 and MaxStreamInitialOffset ($2^{62} - 1$).

-  Validation & Mapping: Added validation checks to ensure stream-initial-offset is rejected on broker versions prior to 4.4, and correctly mapped the argument during queue declaration.

-  Unit Tests: Added comprehensive test coverage for boundaries, version validation, and AMQP argument mapping.

Closes #126